### PR TITLE
readme: minor fix for installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ pip install -U adapters
 
 ```
 git clone https://github.com/adapter-hub/adapters.git
-git checkout adapters
 cd adapters
 pip install .
 ```


### PR DESCRIPTION
Hi :)

this PR has  a minor fix for the installation (from source) section: the `git checkout` command is removed, because there's no longer a `adapters` branch here.