### PR TITLE
Fix DataParallel training with adapters

### DIFF
--- a/src/adapters/methods/bottleneck.py
+++ b/src/adapters/methods/bottleneck.py
@@ -255,7 +255,7 @@ class BottleneckLayer(ComposableAdapterLayerBase, nn.Module):
         for child in adapter_setup:
             if isinstance(child, AdapterCompositionBlock):
                 self.check_composition_valid(adapter_setup, child, lvl)
-                composition_func = self.composition_to_func_map[type(child)]
+                composition_func = self._get_compose_func(type(child))
                 child_state = composition_func(child, state, lvl=lvl + 1)
                 children_states.append(child_state)
             elif child in self.adapter_modules:
@@ -311,7 +311,7 @@ class BottleneckLayer(ComposableAdapterLayerBase, nn.Module):
             )
             if isinstance(child, AdapterCompositionBlock):
                 self.check_composition_valid(adapter_setup, child, lvl)
-                composition_func = self.composition_to_func_map[type(child)]
+                composition_func = self._get_compose_func(type(child))
                 child_state = composition_func(child, child_state, lvl=lvl + 1)
                 children_states.append(child_state)
             elif child in self.adapter_modules:


### PR DESCRIPTION
Closes #650.

The current implementation of composition blocks via `composition_to_func_map` prevents usage with torch's DataParallel built into HF Trainer, as described in #649, #650.
This PR fixes compatibility with DataParallel. Tested with the script provided in #650 running on two GPUs.