### PR TITLE
Fix skipping composition blocks in not applicable layers

### DIFF
--- a/src/adapters/methods/adapter_layer_base.py
+++ b/src/adapters/methods/adapter_layer_base.py
@@ -312,11 +312,7 @@ class ComposableAdapterLayerBase(AdapterLayerBase):
                 state = self.pre_block(adapter_stack_layer, state)
                 state = self.compose_single(adapter_stack_layer, state, lvl=lvl + 1)
             else:
-                raise ValueError(
-                    "Invalid adapter setup: {} is not a valid adapter name or composition block.".format(
-                        adapter_stack_layer.__class__.__name__
-                    )
-                )
+                pass
 
         return state
 
@@ -325,6 +321,9 @@ class ComposableAdapterLayerBase(AdapterLayerBase):
         For fusing multiple adapters using adapter fusion. NOTE: This method has no default implementation.
         """
         # Fuse is currently only applicable to bottleneck adapters, thus don't provide a default implementation
+        # If the adapter setup does not contain any of the adapter modules, return without doing anything
+        if set(self.adapter_modules.keys()).isdisjoint(adapter_setup.flatten()):
+            return state
         raise NotImplementedError()
 
     def compose_split(self, adapter_setup: Split, state: NamedTuple, lvl: int = 0):
@@ -333,6 +332,9 @@ class ComposableAdapterLayerBase(AdapterLayerBase):
         implementation.
         """
         # Split is currently only applicable to bottleneck adapters, thus don't provide a default implementation
+        # If the adapter setup does not contain any of the adapter modules, return without doing anything
+        if set(self.adapter_modules.keys()).isdisjoint(adapter_setup.flatten()):
+            return state
         raise NotImplementedError()
 
     def compose_batch_split(self, adapter_setup: BatchSplit, state: NamedTuple, lvl: int = 0):

--- a/src/adapters/methods/bottleneck.py
+++ b/src/adapters/methods/bottleneck.py
@@ -30,6 +30,7 @@ class BottleneckState(NamedTuple):
         layer_norm (torch.nn.Module, optional): The Transformer layer norm module.
         bottleneck_up (torch.Tensor, optional):
             The up-projected bottleneck MLP output. This is only for Fuse compositions.
+        last (str, optional): Name of the last adapter applied in the composition.
     """
 
     hidden_states: torch.Tensor
@@ -37,6 +38,7 @@ class BottleneckState(NamedTuple):
     adapter_residual: torch.Tensor
     layer_norm: Optional[torch.nn.Module]
     bottleneck_up: Optional[torch.Tensor] = None
+    last: Optional[str] = None
 
 
 class BottleneckLayer(ComposableAdapterLayerBase, nn.Module):
@@ -193,6 +195,7 @@ class BottleneckLayer(ComposableAdapterLayerBase, nn.Module):
             state.adapter_residual[slice_obj],
             state.layer_norm,
             state.bottleneck_up[slice_obj] if state.bottleneck_up is not None else None,
+            state.last,
         )
 
     def pad_and_concat(self, states: List[BottleneckState]) -> BottleneckState:
@@ -204,6 +207,7 @@ class BottleneckLayer(ComposableAdapterLayerBase, nn.Module):
             torch.cat([state.bottleneck_up for state in states], dim=0)
             if states[0].bottleneck_up is not None
             else None,
+            states[-1].last,
         )
 
     def repeat(self, state: BottleneckState, channels: int) -> BottleneckState:
@@ -213,6 +217,7 @@ class BottleneckLayer(ComposableAdapterLayerBase, nn.Module):
             state.adapter_residual.repeat(channels, 1, 1),
             state.layer_norm,
             state.bottleneck_up.repeat(channels, 1, 1) if state.bottleneck_up is not None else None,
+            state.last,
         )
 
     def mean(self, states: List[BottleneckState], weights: torch.Tensor) -> BottleneckState:
@@ -222,6 +227,7 @@ class BottleneckLayer(ComposableAdapterLayerBase, nn.Module):
             states[0].adapter_residual,
             states[0].layer_norm,
             states[0].bottleneck_up,
+            states[-1].last,
         )
 
     def compose_single(self, adapter_setup: str, state: BottleneckState, lvl: int = 0) -> BottleneckState:
@@ -235,7 +241,7 @@ class BottleneckLayer(ComposableAdapterLayerBase, nn.Module):
         hidden_states, up = layer_output[0], layer_output[2]
         self._store_gating_score(adapter_setup, layer_output[-1])
 
-        return BottleneckState(hidden_states, state.input_tensor, state.adapter_residual, state.layer_norm, up)
+        return state._replace(hidden_states=hidden_states, bottleneck_up=up, last=adapter_setup)
 
     def compose_fuse(self, adapter_setup: Fuse, state: BottleneckState, lvl: int = 0):
         """
@@ -245,7 +251,8 @@ class BottleneckLayer(ComposableAdapterLayerBase, nn.Module):
 
         # config of _last_ fused adapter is significant
         fusion_config = self.adapters_config.get_fusion(adapter_setup.name)
-        last_adapter = self.adapters[adapter_setup.last()]
+        last = adapter_setup.last()
+        last_adapter = self.adapters[last]
         hidden_states, query, residual = last_adapter.pre_forward(
             state.hidden_states, state.input_tensor, state.layer_norm, fusion_config=fusion_config
         )
@@ -281,7 +288,7 @@ class BottleneckLayer(ComposableAdapterLayerBase, nn.Module):
             else:
                 hidden_states = fusion_output
 
-        return state._replace(hidden_states=hidden_states)
+        return state._replace(hidden_states=hidden_states, last=last)
 
     def compose_split(self, adapter_setup: Split, state: BottleneckState, lvl: int = 0):
         """
@@ -297,6 +304,7 @@ class BottleneckLayer(ComposableAdapterLayerBase, nn.Module):
         state = self.pre_block(adapter_setup, state)
 
         children_states = []
+        last = None
         for i, child in enumerate(adapter_setup):
             batch_idx = (
                 sum(adapter_setup.splits[:i]),
@@ -314,14 +322,16 @@ class BottleneckLayer(ComposableAdapterLayerBase, nn.Module):
                 composition_func = self._get_compose_func(type(child))
                 child_state = composition_func(child, child_state, lvl=lvl + 1)
                 children_states.append(child_state)
+                last = child_state.last or last
             elif child in self.adapter_modules:
                 child_state = self.compose_single(child, child_state, lvl=lvl + 1)
                 children_states.append(child_state)
+                last = child_state.last or last
             else:
                 pass
 
         hidden_states = torch.cat([child.hidden_states for child in children_states], dim=1)
-        return state._replace(hidden_states=hidden_states)
+        return state._replace(hidden_states=hidden_states, last=last)
 
     def bottleneck_layer_forward(self, hidden_states, residual_input, layer_norm):
         """Forward pass through the adapter layer.
@@ -346,9 +356,9 @@ class BottleneckLayer(ComposableAdapterLayerBase, nn.Module):
 
             state = BottleneckState(hidden_states, residual_input, residual_input, layer_norm)
             state = self.compose(adapter_setup, state)
-            hidden_states, residual_input, _, _, _ = state
+            hidden_states, residual_input, _, _, _, last = state
 
-            last_adapter = self.adapters[adapter_setup.last()]
+            last_adapter = self.adapters[last]
             hidden_states = last_adapter.post_forward(hidden_states, input_hidden_states, residual_input, layer_norm)
 
         elif layer_norm:


### PR DESCRIPTION
Fixes #664.

Changes in this PR:
- Avoid throwing `NotImplementedError` in an unsupported block if none if the child adapters are part of the respective layer.
- Pass along "last" invoked adapter module name in LoRA & bottleneck states to make sure "last" is actually existing in the respective layer.