### PR TITLE
Fix default cache path for adapters loaded from AH repo

### DIFF
--- a/src/adapters/utils.py
+++ b/src/adapters/utils.py
@@ -58,7 +58,9 @@ ADAPTER_HUB_ALL_FILE = ADAPTER_HUB_URL + "all.json"
 ADAPTER_HUB_ADAPTER_ENTRY_JSON = ADAPTER_HUB_URL + "adapters/{}/{}.json"
 
 # the download cache
-torch_cache_home = os.getenv("TORCH_HOME", os.path.join(os.getenv("XDG_CACHE_HOME", os.path.expanduser("~/.cache")), "torch"))
+torch_cache_home = os.getenv(
+    "TORCH_HOME", os.path.join(os.getenv("XDG_CACHE_HOME", os.path.expanduser("~/.cache")), "torch")
+)
 ADAPTER_CACHE = join(torch_cache_home, "adapters")
 
 # these keys are ignored when calculating the config hash

--- a/src/adapters/utils.py
+++ b/src/adapters/utils.py
@@ -35,7 +35,6 @@ from huggingface_hub.utils import (
 )
 from requests.exceptions import HTTPError
 from transformers.utils import http_user_agent, is_remote_url
-from transformers.utils.hub import torch_cache_home
 
 from . import __version__
 from .context import ForwardContext
@@ -59,6 +58,7 @@ ADAPTER_HUB_ALL_FILE = ADAPTER_HUB_URL + "all.json"
 ADAPTER_HUB_ADAPTER_ENTRY_JSON = ADAPTER_HUB_URL + "adapters/{}/{}.json"
 
 # the download cache
+torch_cache_home = os.getenv("TORCH_HOME", os.path.join(os.getenv("XDG_CACHE_HOME", os.path.expanduser("~/.cache")), "torch"))
 ADAPTER_CACHE = join(torch_cache_home, "adapters")
 
 # these keys are ignored when calculating the config hash


### PR DESCRIPTION
Fixes #570.

This applies for adapters loaded from the (now-legacy) AH repo, and if `TORCH_HOME` is not set.