### PR TITLE
Fix compatibility of adapters with HF Accelerate auto device-mapping

### DIFF
--- a/docs/contributing/adding_adapters_to_a_model.md
+++ b/docs/contributing/adding_adapters_to_a_model.md
@@ -36,6 +36,7 @@ Now that we have discussed the purpose of every file in `src/adapters/models/<mo
     - Create a new class in `src/adapters/models/<model_type>/modeling_<model_type>.py` with the name `<class>WithAdapters`. This class should derive from the corresponding mixin and HF class.
     - Copy the function you want to change into this class and modify it.
         - e.g., the `forward` method of the `BertSelfAttention` class must be adapted to support prefix tuning. We therefore create a class `BertSelfAttentionWithAdapters(BertSelfAttentionAdaptersMixin, BertSelfAttention)`, copy the forward method into it and modify it.
+        - if the `forward` method of a module is copied and modified, make sure to call `adapters.utils.patch_forward()` in the module's `init_adapters()` method. This ensures adapters work correctly with the `accelerate` package.
 4. **Modify MODEL_MIXIN_MAPPING**
     - For each mixin whose class was not copied into `modeling_<model_type>.py`, add the mixin/class combination into `MODEL_MIXIN_MAPPING` in the file `src/adapters/models/__init__.py`.
 5. **Create the adapter model:**

--- a/src/adapters/model_mixin.py
+++ b/src/adapters/model_mixin.py
@@ -23,7 +23,7 @@ from .methods.lora import LoRALayer
 from .methods.modeling import Adapter, GLOWCouplingBlock, NICECouplingBlock, init_shared_parameters
 from .methods.prefix_tuning import PrefixTuningLayer, PrefixTuningPool
 from .methods.prompt_tuning import PromptTuningLayer
-from .utils import EMBEDDING_FILE, TOKENIZER_PATH, get_adapter_config_hash, inherit_doc
+from .utils import EMBEDDING_FILE, TOKENIZER_PATH, get_adapter_config_hash, inherit_doc, patch_forward
 from .wrappers.configuration import SUBMODEL_NAMES, init_adapters_config
 
 
@@ -1257,6 +1257,11 @@ class ModelAdaptersMixin(PushAdapterToHubMixin, ABC):
 @inherit_doc
 class ModelBaseAdaptersMixin(ModelAdaptersMixin):
     add_base_adapters = True
+
+    def init_adapters(self, model_config, adapters_config, add_prefix_tuning_pool=True):
+        super().init_adapters(model_config, adapters_config, add_prefix_tuning_pool)
+
+        patch_forward(self)
 
     def post_embedding_forward(self, module, args, embedding_output):
         if isinstance(self, InvertibleAdaptersMixin) or isinstance(self, InvertibleAdaptersWrapperMixin):

--- a/src/adapters/models/albert/mixin_albert.py
+++ b/src/adapters/models/albert/mixin_albert.py
@@ -7,6 +7,7 @@ from ...methods.bottleneck import BottleneckLayer
 from ...methods.lora import LoRALinear
 from ...methods.prefix_tuning import PrefixTuningLayer
 from ...model_mixin import EmbeddingAdaptersMixin, InvertibleAdaptersMixin, ModelBaseAdaptersMixin
+from ...utils import patch_forward
 
 
 class AlbertAttentionAdaptersMixin:
@@ -23,6 +24,7 @@ class AlbertAttentionAdaptersMixin:
         self.prefix_tuning = PrefixTuningLayer(
             self.location_key + "_prefix" if self.location_key else None, model_config, adapters_config
         )
+        patch_forward(self)
 
 
 class AlbertEncoderLayerAdaptersMixin:
@@ -39,6 +41,8 @@ class AlbertEncoderLayerAdaptersMixin:
         self.output_adapters = BottleneckLayer("output_adapter")
 
         self.attention.location_key = "self"
+
+        patch_forward(self)
 
 
 class AlbertModelAdaptersMixin(EmbeddingAdaptersMixin, InvertibleAdaptersMixin, ModelBaseAdaptersMixin):

--- a/src/adapters/models/bart/mixin_bart.py
+++ b/src/adapters/models/bart/mixin_bart.py
@@ -14,6 +14,7 @@ from ...model_mixin import (
     InvertibleAdaptersWrapperMixin,
     ModelBaseAdaptersMixin,
 )
+from ...utils import patch_forward
 
 
 class BartAttentionAdaptersMixin:
@@ -28,6 +29,7 @@ class BartAttentionAdaptersMixin:
         self.prefix_tuning = PrefixTuningLayer(
             self.location_key + "_prefix" if self.location_key else None, model_config, adapters_config
         )
+        patch_forward(self)
 
 
 class BartEncoderLayerAdaptersMixin:
@@ -43,6 +45,8 @@ class BartEncoderLayerAdaptersMixin:
         self.self_attn.location_key = "encoder"
         self.attention_adapters = BottleneckLayer("mh_adapter")
         self.output_adapters = BottleneckLayer("output_adapter")
+
+        patch_forward(self)
 
 
 class BartDecoderLayerAdaptersMixin(BartEncoderLayerAdaptersMixin):
@@ -64,6 +68,9 @@ class BartEncoderAdaptersMixin(InvertibleAdaptersMixin):
 
 class BartDecoderAdaptersMixin:
     """Adds adapters to the BartDecoder module of BART."""
+
+    def init_adapters(self, model_config, adapters_config):
+        patch_forward(self)
 
     def forward(
         self, input_ids: torch.LongTensor = None, encoder_hidden_states: Optional[torch.FloatTensor] = None, **kwargs

--- a/src/adapters/models/beit/mixin_beit.py
+++ b/src/adapters/models/beit/mixin_beit.py
@@ -6,6 +6,7 @@ from ...methods.bottleneck import BottleneckLayer
 from ...methods.lora import LoRALinear
 from ...methods.prefix_tuning import PrefixTuningLayer
 from ...model_mixin import ModelBaseAdaptersMixin
+from ...utils import patch_forward
 
 
 class BeitSelfAttentionAdaptersMixin:
@@ -20,6 +21,7 @@ class BeitSelfAttentionAdaptersMixin:
         self.prefix_tuning = PrefixTuningLayer(
             self.location_key + "_prefix" if self.location_key else None, model_config, adapters_config
         )
+        patch_forward(self)
 
 
 class BeitIntermediateAdaptersMixin:
@@ -40,6 +42,7 @@ class BeitLayerAdaptersMixin:
     def init_adapters(self, model_config, adapters_config):
         self.attention_adapters = BottleneckLayer("mh_adapter")
         self.output_adapters = BottleneckLayer("output_adapter")
+        patch_forward(self)
 
 
 class BeitModelAdaptersMixin(ModelBaseAdaptersMixin):

--- a/src/adapters/models/bert/mixin_bert.py
+++ b/src/adapters/models/bert/mixin_bert.py
@@ -8,6 +8,7 @@ from ...methods.bottleneck import BottleneckLayer
 from ...methods.lora import LoRALinear
 from ...methods.prefix_tuning import PrefixTuningLayer
 from ...model_mixin import EmbeddingAdaptersMixin, InvertibleAdaptersMixin, ModelBaseAdaptersMixin
+from ...utils import patch_forward
 
 
 logger = logging.getLogger(__name__)
@@ -25,6 +26,7 @@ class BertSelfAttentionAdaptersMixin:
         self.prefix_tuning = PrefixTuningLayer(
             self.location_key + "_prefix" if self.location_key else None, model_config, adapters_config
         )
+        patch_forward(self)
 
 
 # For backwards compatibility, BertSelfOutput inherits directly from BottleneckLayer
@@ -37,6 +39,7 @@ class BertSelfOutputAdaptersMixin(BottleneckLayer):
     def init_adapters(self, model_config, adapters_config):
         self.location_key = "mh_adapter"
         super().init_adapters(model_config, adapters_config)
+        patch_forward(self)
 
 
 # For backwards compatibility, BertOutput inherits directly from BottleneckLayer
@@ -49,6 +52,7 @@ class BertOutputAdaptersMixin(BottleneckLayer):
     def init_adapters(self, model_config, adapters_config):
         self.location_key = "output_adapter"
         super().init_adapters(model_config, adapters_config)
+        patch_forward(self)
 
 
 class BertLayerAdaptersMixin:

--- a/src/adapters/models/clip/mixin_clip.py
+++ b/src/adapters/models/clip/mixin_clip.py
@@ -13,6 +13,7 @@ from ...model_mixin import (
     InvertibleAdaptersWrapperMixin,
     ModelBaseAdaptersMixin,
 )
+from ...utils import patch_forward
 
 
 class CLIPAttentionAdaptersMixin:
@@ -27,6 +28,7 @@ class CLIPAttentionAdaptersMixin:
         self.prefix_tuning = PrefixTuningLayer(
             "self_prefix", model_config, adapters_config, add_model_type_to_key=True
         )
+        patch_forward(self)
 
 
 class CLIPEncoderLayerAdaptersMixin:
@@ -39,6 +41,8 @@ class CLIPEncoderLayerAdaptersMixin:
 
         self.attention_adapters = BottleneckLayer("mh_adapter")
         self.output_adapters = BottleneckLayer("output_adapter")
+
+        patch_forward(self)
 
 
 class CLIPEncoderAdaptersMixin:

--- a/src/adapters/models/deberta/mixin_deberta.py
+++ b/src/adapters/models/deberta/mixin_deberta.py
@@ -1,5 +1,6 @@
 from ...methods.lora import LoRAMergedLinear
 from ...methods.prefix_tuning import PrefixTuningLayer
+from ...utils import patch_forward
 
 
 class DebertaSelfAttentionAdaptersMixin:
@@ -12,3 +13,4 @@ class DebertaSelfAttentionAdaptersMixin:
         self.prefix_tuning = PrefixTuningLayer(
             self.location_key + "_prefix" if self.location_key else None, model_config, adapters_config
         )
+        patch_forward(self)

--- a/src/adapters/models/deberta_v2/mixin_deberta_v2.py
+++ b/src/adapters/models/deberta_v2/mixin_deberta_v2.py
@@ -1,5 +1,6 @@
 from ...methods.lora import LoRALinear
 from ...methods.prefix_tuning import PrefixTuningLayer
+from ...utils import patch_forward
 
 
 class DebertaV2SelfAttentionAdaptersMixin:
@@ -14,3 +15,4 @@ class DebertaV2SelfAttentionAdaptersMixin:
         self.prefix_tuning = PrefixTuningLayer(
             self.location_key + "_prefix" if self.location_key else None, model_config, adapters_config
         )
+        patch_forward(self)

--- a/src/adapters/models/gpt2/mixin_gpt2.py
+++ b/src/adapters/models/gpt2/mixin_gpt2.py
@@ -6,6 +6,7 @@ from ...methods.bottleneck import BottleneckLayer
 from ...methods.lora import LoRALinear, LoRAMergedLinear
 from ...methods.prefix_tuning import PrefixTuningLayer
 from ...model_mixin import EmbeddingAdaptersMixin, InvertibleAdaptersMixin, ModelBaseAdaptersMixin
+from ...utils import patch_forward
 
 
 class GPT2AttentionAdaptersMixin:
@@ -25,6 +26,8 @@ class GPT2AttentionAdaptersMixin:
 
         location_key = "cross_prefix" if self.is_cross_attention else "self_prefix"
         self.prefix_tuning = PrefixTuningLayer(location_key, model_config, adapters_config)
+
+        patch_forward(self)
 
 
 class GPT2DecoderBlockAdaptersMixin:
@@ -51,6 +54,8 @@ class GPT2DecoderBlockAdaptersMixin:
 
         self.attention_adapters = BottleneckLayer("mh_adapter")
         self.output_adapters = BottleneckLayer("output_adapter")
+
+        patch_forward(self)
 
 
 class GPT2ModelAdapterMixin(EmbeddingAdaptersMixin, InvertibleAdaptersMixin, ModelBaseAdaptersMixin):

--- a/src/adapters/models/gptj/mixin_gptj.py
+++ b/src/adapters/models/gptj/mixin_gptj.py
@@ -6,6 +6,7 @@ from ...methods.bottleneck import BottleneckLayer
 from ...methods.lora import LoRALinear
 from ...methods.prefix_tuning import PrefixTuningLayer
 from ...model_mixin import EmbeddingAdaptersMixin, InvertibleAdaptersMixin, ModelBaseAdaptersMixin
+from ...utils import patch_forward
 
 
 class GPTJAttentionAdaptersMixin:
@@ -20,6 +21,7 @@ class GPTJAttentionAdaptersMixin:
         self.prefix_tuning = PrefixTuningLayer(
             self.location_key + "_prefix" if self.location_key else None, model_config, adapters_config
         )
+        patch_forward(self)
 
 
 class GPTJMLPAdaptersMixin:
@@ -35,6 +37,8 @@ class GPTJDecoderBlockAdaptersMixin:
     def init_adapters(self, model_config, adapters_config):
         self.attention_adapters = BottleneckLayer("mh_adapter")
         self.output_adapters = BottleneckLayer("output_adapter")
+
+        patch_forward(self)
 
 
 class GPTJModelAdapterMixin(EmbeddingAdaptersMixin, InvertibleAdaptersMixin, ModelBaseAdaptersMixin):

--- a/src/adapters/models/llama/mixin_llama.py
+++ b/src/adapters/models/llama/mixin_llama.py
@@ -6,6 +6,7 @@ from ...methods.bottleneck import BottleneckLayer
 from ...methods.lora import LoRALinear
 from ...methods.prefix_tuning import PrefixTuningLayer
 from ...model_mixin import EmbeddingAdaptersMixin, InvertibleAdaptersMixin, ModelBaseAdaptersMixin
+from ...utils import patch_forward
 
 
 class LlamaAttentionMixin:
@@ -16,6 +17,8 @@ class LlamaAttentionMixin:
 
         self.prefix_tuning = PrefixTuningLayer("self_prefix", model_config, adapters_config)
 
+        patch_forward(self)
+
 
 class LlamaDecoderLayerMixin:
     def init_adapters(self, model_config, adapters_config):
@@ -25,6 +28,8 @@ class LlamaDecoderLayerMixin:
 
         self.attention_adapters = BottleneckLayer("mh_adapter")
         self.output_adapters = BottleneckLayer("output_adapter")
+
+        patch_forward(self)
 
 
 class LlamaModelAdapterMixin(EmbeddingAdaptersMixin, InvertibleAdaptersMixin, ModelBaseAdaptersMixin):

--- a/src/adapters/models/t5/mixin_t5.py
+++ b/src/adapters/models/t5/mixin_t5.py
@@ -13,6 +13,7 @@ from ...model_mixin import (
     ModelBaseAdaptersMixin,
     ModelWithHeadsAdaptersMixin,
 )
+from ...utils import patch_forward
 
 
 class T5AttentionAdaptersMixin:
@@ -27,6 +28,7 @@ class T5AttentionAdaptersMixin:
         self.prefix_tuning = PrefixTuningLayer(
             self.location_key + "_prefix" if self.location_key else None, model_config, adapters_config
         )
+        patch_forward(self)
 
 
 class T5SelfAttentionLayerAdaptersMixin(BottleneckLayer):
@@ -36,6 +38,7 @@ class T5SelfAttentionLayerAdaptersMixin(BottleneckLayer):
     def init_adapters(self, model_config, adapters_config):
         self.location_key = "mh_adapter"
         super().init_adapters(model_config, adapters_config)
+        patch_forward(self)
 
 
 class T5CrossAttentionLayerAdaptersMixin(BottleneckLayer):
@@ -46,6 +49,7 @@ class T5CrossAttentionLayerAdaptersMixin(BottleneckLayer):
         self.location_key = "cross_adapter"
         self.EncDecAttention.location_key = "cross"
         super().init_adapters(model_config, adapters_config)
+        patch_forward(self)
 
 
 class T5FFLayerAdaptersMixin(BottleneckLayer):
@@ -82,6 +86,7 @@ class T5StackAdaptersMixin(InvertibleAdaptersMixin):
     def init_adapters(self, model_config, adapters_config):
         if not self.is_decoder:
             InvertibleAdaptersMixin.init_adapters(self, self.config, adapters_config)
+        patch_forward(self)
 
     def post_embedding_forward(self, embedding_output):
         embedding_output = self.invertible_adapters_forward(embedding_output)

--- a/src/adapters/models/vit/mixin_vit.py
+++ b/src/adapters/models/vit/mixin_vit.py
@@ -6,6 +6,7 @@ from ...methods.bottleneck import BottleneckLayer
 from ...methods.lora import LoRALinear
 from ...methods.prefix_tuning import PrefixTuningLayer
 from ...model_mixin import ModelBaseAdaptersMixin
+from ...utils import patch_forward
 
 
 class ViTSelfAttentionAdaptersMixin:
@@ -20,6 +21,7 @@ class ViTSelfAttentionAdaptersMixin:
         self.prefix_tuning = PrefixTuningLayer(
             self.location_key + "_prefix" if self.location_key else None, model_config, adapters_config
         )
+        patch_forward(self)
 
 
 class ViTIntermediateAdaptersMixin:
@@ -37,6 +39,8 @@ class ViTOutputAdaptersMixin:
         # Wrap layers for LoRA
         self.dense = LoRALinear.wrap(self.dense, "output", model_config, adapters_config)
 
+        patch_forward(self)
+
 
 # Unlike BERT, self attention adapters are added to Layer module in ViT
 class ViTLayerAdaptersMixin:
@@ -44,6 +48,7 @@ class ViTLayerAdaptersMixin:
 
     def init_adapters(self, model_config, adapters_config):
         self.attention_adapters = BottleneckLayer("mh_adapter")
+        patch_forward(self)
 
 
 class ViTModelAdaptersMixin(ModelBaseAdaptersMixin):

--- a/src/adapters/utils.py
+++ b/src/adapters/utils.py
@@ -862,3 +862,12 @@ def prefix_attention_mask(attention_mask, dim: int = 3, prefix_value: int = 0):
         attention_mask = torch.cat((prefix_attention_mask, attention_mask), dim=dim)
 
     return attention_mask
+
+
+def patch_forward(module: torch.nn.Module):
+    # HF Accelerate's `add_hook_to_module()` replaces the module forward method with a wrapper
+    # and stores the original forward method in `_old_forward`. For this to work with Adapters' post-hook wrapping,
+    # we need to explicitly set to potentially overriden forward methods on adapter init.
+    # The `add_hook_to_module()` method is e.g. used for `device_map="auto"` in the `PreTrainedModel.from_pretrained()` method.
+    if hasattr(module, "_old_forward"):
+        module._old_forward = module.__class__.forward.__get__(module, module.__class__)


### PR DESCRIPTION
Adapters currently does not work correctly with passing `device_map="auto"` in a model's `from_pretrained()`. Device auto-mapping is handled by HF accelerate, which wraps the original module forward method.

This PR fixes compatibility of Adapters' post-hoc model wrapping with Accelerate's device auto-mapping via wrapping the forward pass.

Fixing this is required for enabling quantized training of adapters (bottleneck & prefix-tuning) in #663.

The fix can be tested like this:

```python
import adapters
from transformers import AutoTokenizer, AutoModelForSequenceClassification

model_name = "t5-small"

tokenizer = AutoTokenizer.from_pretrained(model_name)
model = AutoModelForSequenceClassification.from_pretrained(
    model_name,
    device_map="auto"
)

adapters.init(model)
model.add_adapter("my_adapter")
model.train_adapter("my_adapter")

model.to("cuda")

inputs = tokenizer("Hello, my dog is cute", return_tensors="pt")
inputs = inputs.to("cuda")

is_accessed = False

def hook_fn(module, args, output):
    global is_accessed
    is_accessed = True
    return output

adapter = model.get_adapter("my_adapter")
first_layer_module = adapter[0]["output_adapter"]
first_layer_module.register_forward_hook(hook_fn)

outputs = model(**inputs)
print(outputs)

assert is_accessed
```