### PR TITLE
Fix reading model info in `get_adapter_info()` for HF

### DIFF
--- a/src/adapters/utils.py
+++ b/src/adapters/utils.py
@@ -815,7 +815,7 @@ def get_adapter_info(adapter_id: str, source: str = "ah") -> Optional[AdapterInf
             return AdapterInfo(
                 source="hf",
                 adapter_id=model_info.modelId,
-                model_name=model_info.config.get("adapters", {}).get("model_name") if model_info.config else None,
+                model_name=model_info.config.get("adapter_transformers", {}).get("model_name") if model_info.config else None,
                 username=model_info.modelId.split("/")[0],
                 sha1_checksum=model_info.sha,
             )

--- a/src/adapters/utils.py
+++ b/src/adapters/utils.py
@@ -815,7 +815,9 @@ def get_adapter_info(adapter_id: str, source: str = "ah") -> Optional[AdapterInf
             return AdapterInfo(
                 source="hf",
                 adapter_id=model_info.modelId,
-                model_name=model_info.config.get("adapter_transformers", {}).get("model_name") if model_info.config else None,
+                model_name=model_info.config.get("adapter_transformers", {}).get("model_name")
+                if model_info.config
+                else None,
                 username=model_info.modelId.split("/")[0],
                 sha1_checksum=model_info.sha,
             )


### PR DESCRIPTION
The config key on HF side has not changed from `adapter_transformers`. Thus, currently the model name is never returned correctly for HF adapters.

This is required to fix the HF hub inference widgets.