### PR TITLE
Fix search on docs.adapterhub.ml

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ _deps = [
     "sentencepiece>=0.1.91,!=0.1.92",
     "sphinx-copybutton==0.5.2",
     "sphinx-markdown-tables==0.0.17",
-    "sphinx-rtd-theme==0.4.3",  # sphinx-rtd-theme==0.5.0 introduced big changes in the style.
+    "sphinx-rtd-theme==2.0.0",
     "sphinx==5.0.2",
     "sphinxext-opengraph==0.4.1",
     "sphinx-intl==2.1.0",


### PR DESCRIPTION
Updated `sphinx-rtd-theme==2.0.0`.

The styling after building it with `make clean && make html` looked the same to me,
but maybe a reviewer could confirm this.

Updating this package fixes the search bar.

<img width="1082" alt="image" src="https://github.com/user-attachments/assets/f27236eb-ed45-44a1-acf3-1d27b14a02bb">