### PR TITLE
Fix LoRA parallel composition

### DIFF
--- a/src/adapters/models/distilbert/modeling_distilbert.py
+++ b/src/adapters/models/distilbert/modeling_distilbert.py
@@ -61,7 +61,8 @@ class MultiHeadSelfAttentionWithAdapters(DistilBertMultiHeadSelfAttentionMixin, 
 
         def shape(x: torch.Tensor) -> torch.Tensor:
             """separate heads"""
-            return x.view(bs, -1, self.n_heads, dim_per_head).transpose(1, 2)
+            # keep first dim due to parallel composition
+            return x.view(x.shape[0], -1, self.n_heads, dim_per_head).transpose(1, 2)
 
         def unshape(x: torch.Tensor) -> torch.Tensor:
             """group heads"""

--- a/src/adapters/models/llama/modeling_llama.py
+++ b/src/adapters/models/llama/modeling_llama.py
@@ -85,9 +85,10 @@ class LlamaAttentionWithAdapters(LlamaAttentionMixin, LlamaAttention):
             key_states = self.k_proj(hidden_states)
             value_states = self.v_proj(hidden_states)
 
-        query_states = query_states.view(bsz, q_len, self.num_heads, self.head_dim).transpose(1, 2)
-        key_states = key_states.view(bsz, q_len, self.num_key_value_heads, self.head_dim).transpose(1, 2)
-        value_states = value_states.view(bsz, q_len, self.num_key_value_heads, self.head_dim).transpose(1, 2)
+        # Loosen constraint on batch_size to allow parallel adapter composition
+        query_states = query_states.view(-1, q_len, self.num_heads, self.head_dim).transpose(1, 2)
+        key_states = key_states.view(-1, q_len, self.num_key_value_heads, self.head_dim).transpose(1, 2)
+        value_states = value_states.view(-1, q_len, self.num_key_value_heads, self.head_dim).transpose(1, 2)
 
         # >>> START AH Changes <<<
         query_states, key_states, value_states = match_attn_matrices_for_parallel(
@@ -188,9 +189,11 @@ class LlamaFlashAttention2WithAdapters(LlamaAttentionMixin, LlamaFlashAttention2
         # Flash attention requires the input to have the shape
         # batch_size x seq_length x head_dim x hidden_dim
         # therefore we just need to keep the original shape
-        query_states = query_states.view(bsz, q_len, self.num_heads, self.head_dim).transpose(1, 2)
-        key_states = key_states.view(bsz, q_len, self.num_key_value_heads, self.head_dim).transpose(1, 2)
-        value_states = value_states.view(bsz, q_len, self.num_key_value_heads, self.head_dim).transpose(1, 2)
+
+        # Loosen constraint on batch_size to allow parallel adapter composition
+        query_states = query_states.view(-1, q_len, self.num_heads, self.head_dim).transpose(1, 2)
+        key_states = key_states.view(-1, q_len, self.num_key_value_heads, self.head_dim).transpose(1, 2)
+        value_states = value_states.view(-1, q_len, self.num_key_value_heads, self.head_dim).transpose(1, 2)
 
         # >>> START AH Changes <<<
         query_states, key_states, value_states = match_attn_matrices_for_parallel(
@@ -320,9 +323,10 @@ class LlamaSdpaAttentionWithAdapters(LlamaAttentionMixin, LlamaSdpaAttention):
         key_states = self.k_proj(hidden_states)
         value_states = self.v_proj(hidden_states)
 
-        query_states = query_states.view(bsz, q_len, self.num_heads, self.head_dim).transpose(1, 2)
-        key_states = key_states.view(bsz, q_len, self.num_key_value_heads, self.head_dim).transpose(1, 2)
-        value_states = value_states.view(bsz, q_len, self.num_key_value_heads, self.head_dim).transpose(1, 2)
+        # Loosen constraint on batch_size to allow parallel adapter composition
+        query_states = query_states.view(-1, q_len, self.num_heads, self.head_dim).transpose(1, 2)
+        key_states = key_states.view(-1, q_len, self.num_key_value_heads, self.head_dim).transpose(1, 2)
+        value_states = value_states.view(-1, q_len, self.num_key_value_heads, self.head_dim).transpose(1, 2)
 
         # >>> START AH Changes <<<
         query_states, key_states, value_states = match_attn_matrices_for_parallel(

--- a/src/adapters/models/mbart/modeling_mbart.py
+++ b/src/adapters/models/mbart/modeling_mbart.py
@@ -30,7 +30,7 @@ class MBartAttentionWithAdapters(BartAttentionAdaptersMixin, MBartAttention):
 
     # Loosen constraint on batch_size to allow parallel adapter composition
     def _shape(self, tensor: torch.Tensor, seq_len: int, bsz: int):
-        return tensor.view(-1, seq_len, self.num_heads, self.head_dim).transpose(1, 2).contiguous()
+        return tensor.view(tensor.shape[0], seq_len, self.num_heads, self.head_dim).transpose(1, 2).contiguous()
 
     def forward(
         self,

--- a/src/adapters/models/mbart/modeling_mbart.py
+++ b/src/adapters/models/mbart/modeling_mbart.py
@@ -28,6 +28,10 @@ from ..bart.mixin_bart import BartAttentionAdaptersMixin, BartDecoderLayerAdapte
 class MBartAttentionWithAdapters(BartAttentionAdaptersMixin, MBartAttention):
     """Multi-headed attention from 'Attention Is All You Need' paper"""
 
+    # Loosen constraint on batch_size to allow parallel adapter composition
+    def _shape(self, tensor: torch.Tensor, seq_len: int, bsz: int):
+        return tensor.view(-1, seq_len, self.num_heads, self.head_dim).transpose(1, 2).contiguous()
+
     def forward(
         self,
         hidden_states: torch.Tensor,

--- a/src/adapters/models/mistral/modeling_mistral.py
+++ b/src/adapters/models/mistral/modeling_mistral.py
@@ -68,15 +68,16 @@ class MistralAttentionWithAdapters(MistralAttentionMixin, MistralAttention):
         key_states = self.k_proj(hidden_states)
         value_states = self.v_proj(hidden_states)
 
-        query_states = query_states.view(bsz, q_len, self.num_heads, self.head_dim).transpose(1, 2)
-        key_states = key_states.view(bsz, q_len, self.num_key_value_heads, self.head_dim).transpose(1, 2)
-        value_states = value_states.view(bsz, q_len, self.num_key_value_heads, self.head_dim).transpose(1, 2)
-
         # >>> START AH Changes <<<
+        # Loosen constraint on batch_size to allow parallel adapter composition
+        query_states = query_states.view(-1, q_len, self.num_heads, self.head_dim).transpose(1, 2)
+        key_states = key_states.view(-1, q_len, self.num_key_value_heads, self.head_dim).transpose(1, 2)
+        value_states = value_states.view(-1, q_len, self.num_key_value_heads, self.head_dim).transpose(1, 2)
+
         query_states, key_states, value_states = match_attn_matrices_for_parallel(
             query_states, key_states, value_states
         )
-        (attention_mask,) = adjust_tensors_for_parallel(query_states, attention_mask)
+        (attention_mask, position_ids) = adjust_tensors_for_parallel(query_states, attention_mask, position_ids)
         # >>> END AH Changes <<<
 
         cos, sin = self.rotary_emb(value_states, position_ids)
@@ -153,15 +154,16 @@ class MistralFlashAttention2WithAdapters(MistralAttentionMixin, MistralFlashAtte
         key_states = self.k_proj(hidden_states)
         value_states = self.v_proj(hidden_states)
 
-        query_states = query_states.view(bsz, q_len, self.num_heads, self.head_dim).transpose(1, 2)
-        key_states = key_states.view(bsz, q_len, self.num_key_value_heads, self.head_dim).transpose(1, 2)
-        value_states = value_states.view(bsz, q_len, self.num_key_value_heads, self.head_dim).transpose(1, 2)
-
         # >>> START AH Changes <<<
+        # Loosen constraint on batch_size to allow parallel adapter composition
+        query_states = query_states.view(-1, q_len, self.num_heads, self.head_dim).transpose(1, 2)
+        key_states = key_states.view(-1, q_len, self.num_key_value_heads, self.head_dim).transpose(1, 2)
+        value_states = value_states.view(-1, q_len, self.num_key_value_heads, self.head_dim).transpose(1, 2)
+
         query_states, key_states, value_states = match_attn_matrices_for_parallel(
             query_states, key_states, value_states
         )
-        (attention_mask,) = adjust_tensors_for_parallel(query_states, attention_mask)
+        (attention_mask, position_ids) = adjust_tensors_for_parallel(query_states, attention_mask, position_ids)
         # >>> END AH Changes <<<
 
         kv_seq_len = key_states.shape[-2]
@@ -310,15 +312,16 @@ class MistralSdpaAttentionWithAdapters(MistralAttentionMixin, MistralSdpaAttenti
         key_states = self.k_proj(hidden_states)
         value_states = self.v_proj(hidden_states)
 
-        query_states = query_states.view(bsz, q_len, self.num_heads, self.head_dim).transpose(1, 2)
-        key_states = key_states.view(bsz, q_len, self.num_key_value_heads, self.head_dim).transpose(1, 2)
-        value_states = value_states.view(bsz, q_len, self.num_key_value_heads, self.head_dim).transpose(1, 2)
-
         # >>> START AH Changes <<<
+        # Loosen constraint on batch_size to allow parallel adapter composition
+        query_states = query_states.view(-1, q_len, self.num_heads, self.head_dim).transpose(1, 2)
+        key_states = key_states.view(-1, q_len, self.num_key_value_heads, self.head_dim).transpose(1, 2)
+        value_states = value_states.view(-1, q_len, self.num_key_value_heads, self.head_dim).transpose(1, 2)
+
         query_states, key_states, value_states = match_attn_matrices_for_parallel(
             query_states, key_states, value_states
         )
-        (attention_mask,) = adjust_tensors_for_parallel(query_states, attention_mask)
+        (attention_mask, position_ids) = adjust_tensors_for_parallel(query_states, attention_mask, position_ids)
         # >>> END AH Changes <<<
 
         cos, sin = self.rotary_emb(value_states, position_ids)

--- a/src/adapters/models/mt5/modeling_mt5.py
+++ b/src/adapters/models/mt5/modeling_mt5.py
@@ -84,7 +84,8 @@ class MT5AttentionWithAdapters(T5AttentionAdaptersMixin, MT5Attention):
 
         def shape(states):
             """projection"""
-            return states.view(batch_size, -1, self.n_heads, self.key_value_proj_dim).transpose(1, 2)
+            # keep first dim due to parallel composition
+            return states.view(states.shape[0], -1, self.n_heads, self.key_value_proj_dim).transpose(1, 2)
 
         def unshape(states):
             """reshape"""

--- a/src/adapters/models/plbart/modeling_plbart.py
+++ b/src/adapters/models/plbart/modeling_plbart.py
@@ -36,6 +36,10 @@ logger = logging.get_logger(__name__)
 class PLBartAttentionWithAdapters(PLBartAttentionAdaptersMixin, PLBartAttention):
     """Multi-headed attention from 'Attention Is All You Need' paper"""
 
+    # Loosen constraint on batch_size to allow parallel adapter composition
+    def _shape(self, tensor: torch.Tensor, seq_len: int, bsz: int):
+        return tensor.view(tensor.shape[0], seq_len, self.num_heads, self.head_dim).transpose(1, 2).contiguous()
+
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -169,6 +173,11 @@ class PLBartAttentionWithAdapters(PLBartAttentionAdaptersMixin, PLBartAttention)
 
 
 class PLBartFlashAttention2WithAdapters(PLBartAttentionAdaptersMixin, PLBartAttention):
+
+    # Loosen constraint on batch_size to allow parallel adapter composition
+    def _reshape(self, tensor: torch.Tensor, seq_len: int, bsz: int):
+        return tensor.view(tensor.shape[0], seq_len, self.num_heads, self.head_dim)
+
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -280,6 +289,11 @@ class PLBartFlashAttention2WithAdapters(PLBartAttentionAdaptersMixin, PLBartAtte
 
 
 class PLBartSdpaAttentionWithAdapters(PLBartAttentionAdaptersMixin, PLBartAttention):
+
+    # Loosen constraint on batch_size to allow parallel adapter composition
+    def _shape(self, tensor: torch.Tensor, seq_len: int, bsz: int):
+        return tensor.view(tensor.shape[0], seq_len, self.num_heads, self.head_dim).transpose(1, 2).contiguous()
+
     def forward(
         self,
         hidden_states: torch.Tensor,

--- a/src/adapters/models/t5/modeling_t5.py
+++ b/src/adapters/models/t5/modeling_t5.py
@@ -84,7 +84,8 @@ class T5AttentionWithAdapters(T5AttentionAdaptersMixin, T5Attention):
 
         def shape(states):
             """projection"""
-            return states.view(batch_size, -1, self.n_heads, self.key_value_proj_dim).transpose(1, 2)
+            # keep first dim due to parallel composition
+            return states.view(states.shape[0], -1, self.n_heads, self.key_value_proj_dim).transpose(1, 2)
 
         def unshape(states):
             """reshape"""

--- a/tests/composition/test_parallel.py
+++ b/tests/composition/test_parallel.py
@@ -283,16 +283,16 @@ class ParallelTrainingMixin:
                 self.assertTrue(torch.allclose(v, state_dict[k.replace(b1, b2)], atol=1e-5))
 
     def test_parallel_training_bottleneck(self):
-        self.run_parallel_training_test(SeqBnConfig(), "adapters.{}")
+        self.run_parallel_training_test(SeqBnConfig(reduction_factor=48), "adapters.{}")
 
     def test_parallel_training_lora(self):
-        self.run_parallel_training_test(LoRAConfig(), "loras.{}")
+        self.run_parallel_training_test(LoRAConfig(r=1), "loras.{}")
 
     def test_parallel_training_prefix_tuning(self):
         self.run_parallel_training_test(PrefixTuningConfig(), "prefix_tunings.{}")
 
     def test_parallel_training_equivalent_to_single_bottleneck(self):
-        self.run_parallel_training_equivalent_to_single(SeqBnConfig())
+        self.run_parallel_training_equivalent_to_single(SeqBnConfig(reduction_factor=48))
 
     def test_parallel_training_equivalent_to_single_prefix_tuning(self):
         self.run_parallel_training_equivalent_to_single(PrefixTuningConfig())
@@ -301,8 +301,8 @@ class ParallelTrainingMixin:
         model = AutoAdapterModel.from_config(self.config())
         model.eval()
 
-        a1, a2 = self.create_twin_adapters(model, "a", SeqBnConfig())
-        b1, b2 = self.create_twin_adapters(model, "b", SeqBnConfig())
+        a1, a2 = self.create_twin_adapters(model, "a", SeqBnConfig(reduction_factor=48))
+        b1, b2 = self.create_twin_adapters(model, "b", SeqBnConfig(reduction_factor=48))
 
         state_dict = model.state_dict()
         for k, v in state_dict.items():

--- a/tests/composition/test_parallel.py
+++ b/tests/composition/test_parallel.py
@@ -3,7 +3,14 @@ import random
 
 import torch
 
-from adapters import ADAPTER_MODEL_MAPPING, AutoAdapterModel, PrefixTuningConfig, SeqBnConfig, T5AdapterModel
+from adapters import (
+    ADAPTER_MODEL_MAPPING,
+    AutoAdapterModel,
+    LoRAConfig,
+    PrefixTuningConfig,
+    SeqBnConfig,
+    T5AdapterModel,
+)
 from adapters.composition import BatchSplit, Parallel
 from adapters.models.bert_generation.adapter_model import BertGenerationAdapterModel
 from transformers import MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING, Trainer, TrainingArguments
@@ -277,6 +284,9 @@ class ParallelTrainingMixin:
 
     def test_parallel_training_bottleneck(self):
         self.run_parallel_training_test(SeqBnConfig(), "adapters.{}")
+
+    def test_parallel_training_lora(self):
+        self.run_parallel_training_test(LoRAConfig(), "loras.{}")
 
     def test_parallel_training_prefix_tuning(self):
         self.run_parallel_training_test(PrefixTuningConfig(), "prefix_tunings.{}")

--- a/tests/test_deberta.py
+++ b/tests/test_deberta.py
@@ -42,7 +42,8 @@ class DebertaAdapterTest(
     DebertaAdapterTestBase,
     unittest.TestCase,
 ):
-    pass
+    def test_parallel_training_lora(self):
+        self.skipTest("Not supported for DeBERTa")
 
 
 @require_torch

--- a/tests/test_gpt2.py
+++ b/tests/test_gpt2.py
@@ -54,7 +54,8 @@ class GPT2AdapterTest(
     GPT2AdapterTestBase,
     unittest.TestCase,
 ):
-    pass
+    def test_parallel_training_lora(self):
+        self.skipTest("Not supported for GPT2")
 
 
 @require_torch

--- a/tests/test_whisper.py
+++ b/tests/test_whisper.py
@@ -59,7 +59,8 @@ class WhisperAdapterTest(
     WhisperAdapterTestBase,
     unittest.TestCase,
 ):
-    pass
+    def test_parallel_training_lora(self):
+        self.skipTest("Not supported for Whisper")
 
 
 @require_torch


### PR DESCRIPTION
Currently, many model implementation don't handle bsz replication caused by parallel composition correctly for attention matrix LoRAs. This PRs loosens bsz reshaping to enable this. Also adds a test case for LoRA parallel.

Resolves #744.