### PR TITLE
Allow specifying adapter dtype in AdapterConfig

### DIFF
--- a/src/adapters/configuration/adapter_config.py
+++ b/src/adapters/configuration/adapter_config.py
@@ -483,6 +483,7 @@ class LoRAConfig(AdapterConfig):
             Place a trainable gating module besides the added parameter module to control module activation. This is
             e.g. used for UniPELT. Defaults to False. Note that modules with use_gating=True cannot be merged using
             `merge_adapter()`.
+        dtype (str, optional): torch dtype for reparametrization tensors. Defaults to None.
     """
 
     architecture: Optional[str] = "lora"
@@ -542,6 +543,7 @@ class ReftConfig(AdapterConfig):
         subtract_projection (bool): If True, subtract the projection of the input.
         dropout (float): The dropout rate used in the intervention layer.
         non_linearity (str): The activation function used in the intervention layer.
+        dtype (str, optional): torch dtype for intervention tensors. Defaults to None.
     """
 
     layers: Union[Literal["all"], List[int]]

--- a/src/adapters/configuration/adapter_config.py
+++ b/src/adapters/configuration/adapter_config.py
@@ -3,6 +3,8 @@ from collections.abc import Mapping
 from dataclasses import FrozenInstanceError, asdict, dataclass, field, replace
 from typing import List, Literal, Optional, Union
 
+import torch
+
 from ..utils import resolve_adapter_config
 
 
@@ -499,6 +501,7 @@ class LoRAConfig(AdapterConfig):
     composition_mode: str = "add"
     init_weights: str = "lora"
     use_gating: bool = False
+    dtype: torch.dtype = torch.float32
 
 
 @dataclass(eq=False)
@@ -521,6 +524,7 @@ class IA3Config(LoRAConfig):
     composition_mode: str = "scale"
     init_weights: str = "ia3"
     use_gating: bool = False
+    dtype: torch.dtype = torch.float32
 
 
 @dataclass(eq=False)
@@ -551,6 +555,7 @@ class ReftConfig(AdapterConfig):
     subtract_projection = True
     dropout: float = 0.05
     non_linearity: Optional[str] = None
+    dtype: torch.dtype = torch.float32
 
     architecture: str = "reft"
 
@@ -583,6 +588,7 @@ class NoReftConfig(ReftConfig):
     r: int = 1
     orthogonality: bool = False
     tied_weights: bool = False
+    dtype: torch.dtype = torch.float32
 
 
 @dataclass(eq=False)
@@ -598,6 +604,7 @@ class DiReftConfig(ReftConfig):
     orthogonality: bool = False
     tied_weights: bool = False
     subtract_projection = False
+    dtype: torch.dtype = torch.float32
 
 
 class ConfigUnion(AdapterConfig):

--- a/src/adapters/configuration/adapter_config.py
+++ b/src/adapters/configuration/adapter_config.py
@@ -3,8 +3,6 @@ from collections.abc import Mapping
 from dataclasses import FrozenInstanceError, asdict, dataclass, field, replace
 from typing import List, Literal, Optional, Union
 
-import torch
-
 from ..utils import resolve_adapter_config
 
 
@@ -501,7 +499,7 @@ class LoRAConfig(AdapterConfig):
     composition_mode: str = "add"
     init_weights: str = "lora"
     use_gating: bool = False
-    dtype: torch.dtype = torch.float32
+    dtype: Optional[str] = None
 
 
 @dataclass(eq=False)
@@ -524,7 +522,7 @@ class IA3Config(LoRAConfig):
     composition_mode: str = "scale"
     init_weights: str = "ia3"
     use_gating: bool = False
-    dtype: torch.dtype = torch.float32
+    dtype: Optional[str] = None
 
 
 @dataclass(eq=False)
@@ -555,7 +553,7 @@ class ReftConfig(AdapterConfig):
     subtract_projection = True
     dropout: float = 0.05
     non_linearity: Optional[str] = None
-    dtype: torch.dtype = torch.float32
+    dtype: Optional[str] = None
 
     architecture: str = "reft"
 
@@ -574,6 +572,7 @@ class LoReftConfig(ReftConfig):
     r: int = 1
     orthogonality: bool = True
     tied_weights: bool = False
+    dtype: Optional[str] = None
 
 
 @dataclass(eq=False)
@@ -588,7 +587,7 @@ class NoReftConfig(ReftConfig):
     r: int = 1
     orthogonality: bool = False
     tied_weights: bool = False
-    dtype: torch.dtype = torch.float32
+    dtype: Optional[str] = None
 
 
 @dataclass(eq=False)
@@ -604,7 +603,7 @@ class DiReftConfig(ReftConfig):
     orthogonality: bool = False
     tied_weights: bool = False
     subtract_projection = False
-    dtype: torch.dtype = torch.float32
+    dtype: Optional[str] = None
 
 
 class ConfigUnion(AdapterConfig):

--- a/src/adapters/methods/lora.py
+++ b/src/adapters/methods/lora.py
@@ -52,8 +52,8 @@ class LoRA(nn.Module):
             self.lora_dropout = lambda x: x
 
         # Actual trainable parameters
-        self.lora_A = nn.Parameter(torch.zeros(lora_A_shape))
-        self.lora_B = nn.Parameter(torch.zeros(lora_B_shape))
+        self.lora_A = nn.Parameter(torch.zeros(lora_A_shape, dtype=config.dtype))
+        self.lora_B = nn.Parameter(torch.zeros(lora_B_shape, dtype=config.dtype))
         self.scaling = self.lora_alpha / self.r
 
         # For compatibility with (IA)^3, allow all init_weights types here.

--- a/src/adapters/methods/lora.py
+++ b/src/adapters/methods/lora.py
@@ -51,9 +51,10 @@ class LoRA(nn.Module):
         else:
             self.lora_dropout = lambda x: x
 
+        dtype = getattr(torch, config.dtype) if config.dtype else None
         # Actual trainable parameters
-        self.lora_A = nn.Parameter(torch.zeros(lora_A_shape, dtype=config.dtype))
-        self.lora_B = nn.Parameter(torch.zeros(lora_B_shape, dtype=config.dtype))
+        self.lora_A = nn.Parameter(torch.zeros(lora_A_shape, dtype=dtype))
+        self.lora_B = nn.Parameter(torch.zeros(lora_B_shape, dtype=dtype))
         self.scaling = self.lora_alpha / self.r
 
         # For compatibility with (IA)^3, allow all init_weights types here.

--- a/src/adapters/methods/reft.py
+++ b/src/adapters/methods/reft.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 import torch
 import torch.nn as nn

--- a/src/adapters/methods/reft.py
+++ b/src/adapters/methods/reft.py
@@ -18,7 +18,7 @@ class ReftUnit(nn.Module):
         subtract_projection: bool = True,
         non_linearity: str = None,
         dropout: float = 0.0,
-        dtype: torch.dtype = torch.float32,
+        dtype: Optional[torch.dtype] = None,
     ):
         super().__init__()
         self.orthogonal = orthogonal
@@ -51,6 +51,7 @@ class ReftModule(nn.Module):
         self.suffix_positions = config.suffix_positions
         self.tied_weights = config.tied_weights
         n_units = 1 if config.tied_weights else 2
+        dtype = getattr(torch, config.dtype) if config.dtype else None
         self.units = nn.ModuleList(
             [
                 ReftUnit(
@@ -60,7 +61,7 @@ class ReftModule(nn.Module):
                     config.subtract_projection,
                     config.non_linearity,
                     config.dropout,
-                    config.dtype,
+                    dtype,
                 )
                 for _ in range(n_units)
             ]

--- a/src/adapters/methods/reft.py
+++ b/src/adapters/methods/reft.py
@@ -18,12 +18,13 @@ class ReftUnit(nn.Module):
         subtract_projection: bool = True,
         non_linearity: str = None,
         dropout: float = 0.0,
+        dtype: torch.dtype = torch.float32,
     ):
         super().__init__()
         self.orthogonal = orthogonal
-        self.learned_source = nn.Linear(in_dim, r_dim, bias=True)
+        self.learned_source = nn.Linear(in_dim, r_dim, bias=True, dtype=dtype)
 
-        projection = nn.Linear(in_dim, r_dim, bias=False)
+        projection = nn.Linear(in_dim, r_dim, bias=False, dtype=dtype)
         if orthogonal:
             self.projection = nn.utils.parametrizations.orthogonal(projection)
         else:
@@ -59,6 +60,7 @@ class ReftModule(nn.Module):
                     config.subtract_projection,
                     config.non_linearity,
                     config.dropout,
+                    config.dtype,
                 )
                 for _ in range(n_units)
             ]


### PR DESCRIPTION
Aims to fix https://github.com/adapter-hub/adapters/issues/766
Backwards compatible, since `dtype` defaults to `None` if not set in `AdapterConfig`. 