### PR TITLE
Fix default Lora/ (IA)^3 scaling in forward

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ _deps = [
     "isort>=5.5.4",
     "Jinja2==2.11.3",
     "nltk",
+    "packaging",
     "parameterized",
     "pillow",
     "protobuf",
@@ -136,11 +137,12 @@ extras["dev"] = (
 # when modifying the following list, make sure to update src/transformers/dependency_versions_check.py
 install_requires = [
     deps["transformers"],
+    deps["packaging"],
 ]
 
 setup(
     name="adapters",
-    version="1.0.1",
+    version="1.1.0.dev0",
     author="The AdapterHub team and community contributors",
     author_email="calpt@mail.de",
     description="A Unified Library for Parameter-Efficient and Modular Transfer Learning",

--- a/src/adapters/__init__.py
+++ b/src/adapters/__init__.py
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.0.1"
+__version__ = "1.1.0.dev0"
 
 from typing import TYPE_CHECKING
 

--- a/src/adapters/loading.py
+++ b/src/adapters/loading.py
@@ -371,7 +371,7 @@ class AdapterLoader(WeightsLoader):
 
     def _fix_backward_compat(self, config):
         # Fix error in previous versions for LoRA/ (IA)^3
-        if config["version"].startswith("adapters.") and Version(config["version"][9:]) < Version("1.1.0"):
+        if config.get("version", "").startswith("adapters.") and Version(config["version"][9:]) < Version("1.1.0"):
             if (
                 config["config"].get("architecture", None) == "lora"
                 and config["config"]["r"] != config["config"]["alpha"]

--- a/src/adapters/loading.py
+++ b/src/adapters/loading.py
@@ -372,7 +372,10 @@ class AdapterLoader(WeightsLoader):
     def _fix_backward_compat(self, config):
         # Fix error in previous versions for LoRA/ (IA)^3
         if config["version"].startswith("adapters.") and Version(config["version"][9:]) < Version("1.1.0"):
-            if config["config"].get("architecture", None) == "lora" and config["config"]["r"] != config["config"]["alpha"]:
+            if (
+                config["config"].get("architecture", None) == "lora"
+                and config["config"]["r"] != config["config"]["alpha"]
+            ):
                 logger.warning(
                     "Loading a LoRA trained using a faulty library version. Editing the configuration to make sure the adapter works as trained."
                     "See https://github.com/adapter-hub/adapters/pull/770 for more."

--- a/src/adapters/loading.py
+++ b/src/adapters/loading.py
@@ -371,7 +371,11 @@ class AdapterLoader(WeightsLoader):
 
     def _fix_backward_compat(self, config):
         # Fix error in previous versions for LoRA/ (IA)^3
-        if config.get("version", "").startswith("adapters.") and Version(config["version"][9:]) < Version("1.1.0"):
+        ADAPTER_PREFIX = "adapters."
+        MIN_VERSION = Version("1.1.0")
+
+        version = config.get("version", "")
+        if version.startswith(ADAPTER_PREFIX) and Version(version[len(ADAPTER_PREFIX):]) < MIN_VERSION:
             if (
                 config["config"].get("architecture", None) == "lora"
                 and config["config"]["r"] != config["config"]["alpha"]

--- a/src/adapters/loading.py
+++ b/src/adapters/loading.py
@@ -381,7 +381,7 @@ class AdapterLoader(WeightsLoader):
                 and config["config"]["r"] != config["config"]["alpha"]
             ):
                 logger.warning(
-                    "Loading a LoRA trained using a faulty library version. Editing the configuration to make sure the adapter works as trained."
+                    "Loading a LoRA trained using a faulty scaling implementation. Editing the configuration to make sure the adapter works as trained."
                     "See https://github.com/adapter-hub/adapters/pull/770 for more."
                 )
                 config["config"]["alpha"] = config["config"]["r"]

--- a/src/adapters/loading.py
+++ b/src/adapters/loading.py
@@ -6,6 +6,7 @@ from os.path import exists, isdir, isfile, join
 from typing import Callable, Mapping, Optional, Sequence, Tuple
 
 import torch
+from packaging.version import Version
 
 
 try:
@@ -368,6 +369,16 @@ class AdapterLoader(WeightsLoader):
             k = k.replace(old, new)
         return k
 
+    def _fix_backward_compat(self, config):
+        # Fix error in previous versions for LoRA/ (IA)^3
+        if config["version"].startswith("adapters.") and Version(config["version"][9:]) < Version("1.1.0"):
+            if config["config"]["architecture"] == "lora" and config["config"]["r"] != config["config"]["alpha"]:
+                logger.warning(
+                    "Loading a LoRA trained using a faulty library version. Editing the configuration to make sure the adapter works as trained."
+                    "See https://github.com/adapter-hub/adapters/pull/770 for more."
+                )
+                config["config"]["alpha"] = config["config"]["r"]
+
     # This method is used to remove unnecessary invertible adapters from task adapters using the old format.
     # In the old format, task adapters e.g. using seq_bn config specify inv. adapters but don't use them.
     # As inv. adapters would be incorrectly used in the new implementation,
@@ -560,6 +571,8 @@ class AdapterLoader(WeightsLoader):
                 # The conversion to a set and then back to a list removes all duplicates
                 leave_out = list(set(leave_out + config["config"]["leave_out"]))
             config["config"]["leave_out"] = leave_out
+        # Fix issues
+        self._fix_backward_compat(config)
 
         adapter_name = load_as or config["name"]
         # If the adapter is not part of the model, add it

--- a/src/adapters/loading.py
+++ b/src/adapters/loading.py
@@ -381,7 +381,7 @@ class AdapterLoader(WeightsLoader):
                 and config["config"]["r"] != config["config"]["alpha"]
             ):
                 logger.warning(
-                    "Loading a LoRA trained using a faulty scaling implementation. Editing the configuration to make sure the adapter works as trained."
+                    "Loading a LoRA trained using a faulty scaling implementation of a previous library version. Editing the configuration to make sure the adapter works as trained."
                     "See https://github.com/adapter-hub/adapters/pull/770 for more."
                 )
                 config["config"]["alpha"] = config["config"]["r"]

--- a/src/adapters/loading.py
+++ b/src/adapters/loading.py
@@ -372,7 +372,7 @@ class AdapterLoader(WeightsLoader):
     def _fix_backward_compat(self, config):
         # Fix error in previous versions for LoRA/ (IA)^3
         if config["version"].startswith("adapters.") and Version(config["version"][9:]) < Version("1.1.0"):
-            if config["config"]["architecture"] == "lora" and config["config"]["r"] != config["config"]["alpha"]:
+            if config["config"].get("architecture", None) == "lora" and config["config"]["r"] != config["config"]["alpha"]:
                 logger.warning(
                     "Loading a LoRA trained using a faulty library version. Editing the configuration to make sure the adapter works as trained."
                     "See https://github.com/adapter-hub/adapters/pull/770 for more."

--- a/src/adapters/loading.py
+++ b/src/adapters/loading.py
@@ -375,7 +375,7 @@ class AdapterLoader(WeightsLoader):
         MIN_VERSION = Version("1.1.0")
 
         version = config.get("version", "")
-        if version.startswith(ADAPTER_PREFIX) and Version(version[len(ADAPTER_PREFIX):]) < MIN_VERSION:
+        if version.startswith(ADAPTER_PREFIX) and Version(version[len(ADAPTER_PREFIX) :]) < MIN_VERSION:
             if (
                 config["config"].get("architecture", None) == "lora"
                 and config["config"]["r"] != config["config"]["alpha"]

--- a/src/adapters/methods/lora.py
+++ b/src/adapters/methods/lora.py
@@ -99,6 +99,7 @@ class LoRA(nn.Module):
             hidden_states = hidden_states * gate
         else:
             gate = None
+            hidden_states = hidden_states * self.scaling
 
         return hidden_states, gate
 
@@ -170,6 +171,7 @@ class IA3(nn.Module):
             hidden_states = hidden_states * gate
         else:
             gate = None
+            hidden_states = hidden_states * self.scaling
 
         return hidden_states, gate
 


### PR DESCRIPTION
Resolves issue described in #760.

**IMPORTANT**: this fix restores weights compatibility with adapter-transformers. Compatibility to previous adapters versions is kept via a compat patch.

## Details

The current implementation of LoRA/ (IA)^3 in `adapters ` versions < 1.1.0 does not correctly implement adapter states scaling via the LoRA `alpha` attribute, effectively ignoring `alpha` and always applying a scaling of 1.0.
This PR restores the correct original behavior as found in adapter-transformers/ original LoRA implementation.

As this change breaks all adapters pre-trained using `adapters` versions 0.1.0 - 1.0.1, a backward compatibility patch is introduced that automatically sets `alpha = r` for LoRAs for adapters that were trained using affected versions. This ensures all previous adapters continue to behave exactly as trained (ie give the exact same output using newer versions).