### PR TITLE
Allow saving, loading and pushing adapter compositions together

### DIFF
--- a/docs/adapter_composition.md
+++ b/docs/adapter_composition.md
@@ -125,6 +125,8 @@ model.active_adapters = ac.Fuse("d", "e", "f")
 
 To learn how training an _AdapterFusion_ layer works, check out [this Colab notebook](https://colab.research.google.com/github/Adapter-Hub/adapters/blob/main/notebooks/03_Adapter_Fusion.ipynb) from the `adapters` repo.
 
+To save and upload the full composition setup with adapters and fusion layer in one line of code, check out the docs on [saving and loading adapter compositions](loading.md#saving-and-loading-adapter-compositions).
+
 ### Retrieving AdapterFusion attentions
 
 Finally, it is possible to retrieve the attention scores computed by each fusion layer in a forward pass of the model.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -105,7 +105,7 @@ model = AutoAdapterModel.from_pretrained(example_path)
 model.load_adapter(example_path)
 ```
 
-Similar to how the weights of the full model are saved, the `save_adapter()` will create a file for saving the adapter weights and a file for saving the adapter configuration in the specified directory.
+Similar to how the weights of the full model are saved, [`save_adapter()`](adapters.ModelWithHeadsAdaptersMixin.save_adapter) will create a file for saving the adapter weights and a file for saving the adapter configuration in the specified directory.
 
 Finally, if we have finished working with adapters, we can restore the base Transformer to its original form by deactivating and deleting the adapter:
 

--- a/src/adapters/composition.py
+++ b/src/adapters/composition.py
@@ -1,4 +1,5 @@
 import itertools
+import sys
 import warnings
 from collections.abc import Sequence
 from typing import List, Optional, Set, Tuple, Union
@@ -45,6 +46,31 @@ class AdapterCompositionBlock(Sequence):
     def flatten(self) -> Set[str]:
         return set(itertools.chain(*[[b] if isinstance(b, str) else b.flatten() for b in self.children]))
 
+    def _get_save_kwargs(self):
+        return None
+
+    def to_dict(self):
+        save_dict = {
+            "type": self.__class__.__name__,
+            "children": [
+                c.to_dict() if isinstance(c, AdapterCompositionBlock) else {"type": "single", "children": [c]}
+                for c in self.children
+            ],
+        }
+        if kwargs := self._get_save_kwargs():
+            save_dict["kwargs"] = kwargs
+        return save_dict
+
+    @classmethod
+    def from_dict(cls, data):
+        children = []
+        for child in data["children"]:
+            if child["type"] == "single":
+                children.append(child["children"][0])
+            else:
+                children.append(cls.from_dict(child))
+        return getattr(sys.modules[__name__], data["type"])(*children, **data.get("kwargs", {}))
+
 
 class Parallel(AdapterCompositionBlock):
     def __init__(self, *parallel_adapters: List[str]):
@@ -80,11 +106,17 @@ class Split(AdapterCompositionBlock):
         super().__init__(*split_adapters)
         self.splits = splits if isinstance(splits, list) else [splits] * len(split_adapters)
 
+    def _get_save_kwargs(self):
+        return {"splits": self.splits}
+
 
 class BatchSplit(AdapterCompositionBlock):
     def __init__(self, *split_adapters: List[Union[AdapterCompositionBlock, str]], batch_sizes: Union[List[int], int]):
         super().__init__(*split_adapters)
         self.batch_sizes = batch_sizes if isinstance(batch_sizes, list) else [batch_sizes] * len(split_adapters)
+
+    def _get_save_kwargs(self):
+        return {"batch_sizes": self.batch_sizes}
 
 
 class Average(AdapterCompositionBlock):
@@ -104,6 +136,9 @@ class Average(AdapterCompositionBlock):
                 self.weights = weights
         else:
             self.weights = [1 / len(average_adapters)] * len(average_adapters)
+
+    def _get_save_kwargs(self):
+        return {"weights": self.weights}
 
 
 # Mapping each composition block type to the allowed nested types

--- a/src/adapters/hub_mixin.py
+++ b/src/adapters/hub_mixin.py
@@ -4,6 +4,8 @@ from typing import List, Optional, Union
 
 from transformers.utils.generic import working_or_temp_dir
 
+from .composition import AdapterCompositionBlock
+
 
 logger = logging.getLogger(__name__)
 
@@ -35,7 +37,7 @@ Now, the adapter can be loaded and activated like this:
 from adapters import AutoAdapterModel
 
 model = AutoAdapterModel.from_pretrained("{model_name}")
-adapter_name = model.load_adapter("{adapter_repo_name}", set_active=True)
+adapter_name = model.{load_fn}("{adapter_repo_name}", set_active=True)
 ```
 
 ## Architecture & Training
@@ -66,6 +68,7 @@ class PushAdapterToHubMixin:
         language: Optional[str] = None,
         license: Optional[str] = None,
         metrics: Optional[List[str]] = None,
+        load_fn: str = "load_adapter",
         **kwargs,
     ):
         # Key remains "adapter-transformers", see: https://github.com/huggingface/huggingface.js/pull/459
@@ -103,6 +106,7 @@ class PushAdapterToHubMixin:
             model_name=self.model_name,
             dataset_name=dataset_name,
             head_info=head_info,
+            load_fn=load_fn,
             adapter_repo_name=adapter_repo_name,
             architecture_training=kwargs.pop("architecture_training", DEFAULT_TEXT),
             results=kwargs.pop("results", DEFAULT_TEXT),
@@ -133,8 +137,6 @@ class PushAdapterToHubMixin:
         Args:
             repo_id (str): The name of the repository on the model hub to upload to.
             adapter_name (str): The name of the adapter to be uploaded.
-            organization (str, optional): Organization in which to push the adapter
-                (you must be a member of this organization). Defaults to None.
             datasets_tag (str, optional): Dataset identifier from https://huggingface.co/datasets. Defaults to
                 None.
             local_path (str, optional): Local path used as clone directory of the adapter repository.
@@ -156,6 +158,8 @@ class PushAdapterToHubMixin:
                 Branch to push the uploaded files to.
             commit_description (`str`, *optional*):
                 The description of the commit that will be created
+            adapter_card_kwargs (Optional[dict], optional): Additional arguments to pass to the adapter card text generation.
+                Currently includes: tags, language, license, metrics, architecture_training, results, citation.
 
         Returns:
             str: The url of the adapter repository on the model hub.
@@ -178,6 +182,91 @@ class PushAdapterToHubMixin:
                     adapter_name,
                     repo_id,
                     datasets_tag=datasets_tag,
+                    **adapter_card_kwargs,
+                )
+            return self._upload_modified_files(
+                work_dir,
+                repo_id,
+                files_timestamps,
+                commit_message=commit_message,
+                token=token,
+                create_pr=create_pr,
+                revision=revision,
+                commit_description=commit_description,
+            )
+
+    def push_adapter_setup_to_hub(
+        self,
+        repo_id: str,
+        adapter_setup: Union[str, list, AdapterCompositionBlock],
+        head_setup: Optional[Union[bool, str, list, AdapterCompositionBlock]] = None,
+        datasets_tag: Optional[str] = None,
+        local_path: Optional[str] = None,
+        commit_message: Optional[str] = None,
+        private: Optional[bool] = None,
+        token: Optional[Union[bool, str]] = None,
+        overwrite_adapter_card: bool = False,
+        create_pr: bool = False,
+        revision: str = None,
+        commit_description: str = None,
+        adapter_card_kwargs: Optional[dict] = None,
+    ):
+        """Upload an adapter to HuggingFace's Model Hub.
+
+        Args:
+            repo_id (str): The name of the repository on the model hub to upload to.
+            adapter_setup (Union[str, list, AdapterCompositionBlock]): The adapter setup to be uploaded. Usually an adapter composition block.
+            head_setup (Optional[Union[bool, str, list, AdapterCompositionBlock]], optional): The head setup to be uploaded.
+            datasets_tag (str, optional): Dataset identifier from https://huggingface.co/datasets. Defaults to
+                None.
+            local_path (str, optional): Local path used as clone directory of the adapter repository.
+                If not specified, will create a temporary directory. Defaults to None.
+            commit_message (:obj:`str`, `optional`):
+                Message to commit while pushing. Will default to :obj:`"add config"`, :obj:`"add tokenizer"` or
+                :obj:`"add model"` depending on the type of the class.
+            private (:obj:`bool`, `optional`):
+                Whether or not the repository created should be private (requires a paying subscription).
+            token (`bool` or `str`, *optional*):
+                The token to use as HTTP bearer authorization for remote files. If `True`, will use the token generated
+                when running `huggingface-cli login` (stored in `~/.huggingface`). Will default to `True` if `repo_url`
+                is not specified.
+            overwrite_adapter_card (bool, optional): Overwrite an existing adapter card with a newly generated one.
+                If set to `False`, will only generate an adapter card, if none exists. Defaults to False.
+            create_pr (bool, optional):
+                Whether or not to create a PR with the uploaded files or directly commit.
+            revision (`str`, *optional*):
+                Branch to push the uploaded files to.
+            commit_description (`str`, *optional*):
+                The description of the commit that will be created
+            adapter_card_kwargs (Optional[dict], optional): Additional arguments to pass to the adapter card text generation.
+                Currently includes: tags, language, license, metrics, architecture_training, results, citation.
+
+        Returns:
+            str: The url of the adapter repository on the model hub.
+        """
+        use_temp_dir = not os.path.isdir(local_path) if local_path else True
+
+        # Create repo or get retrieve an existing repo
+        repo_id = self._create_repo(repo_id, private=private, token=token)
+
+        # Commit and push
+        logger.info('Pushing adapter setup "%s" to model hub at %s ...', adapter_setup, repo_id)
+        with working_or_temp_dir(working_dir=local_path, use_temp_dir=use_temp_dir) as work_dir:
+            files_timestamps = self._get_files_timestamps(work_dir)
+            # Save adapter and optionally create model card
+            if head_setup is not None:
+                save_kwargs = {"head_setup": head_setup}
+            else:
+                save_kwargs = {}
+            self.save_adapter_setup(work_dir, adapter_setup, **save_kwargs)
+            if overwrite_adapter_card or not os.path.exists(os.path.join(work_dir, "README.md")):
+                adapter_card_kwargs = adapter_card_kwargs or {}
+                self._save_adapter_card(
+                    work_dir,
+                    str(adapter_setup),
+                    repo_id,
+                    datasets_tag=datasets_tag,
+                    load_fn="load_adapter_setup",
                     **adapter_card_kwargs,
                 )
             return self._upload_modified_files(

--- a/src/adapters/hub_mixin.py
+++ b/src/adapters/hub_mixin.py
@@ -211,7 +211,7 @@ class PushAdapterToHubMixin:
         commit_description: str = None,
         adapter_card_kwargs: Optional[dict] = None,
     ):
-        """Upload an adapter to HuggingFace's Model Hub.
+        """Upload an adapter setup to HuggingFace's Model Hub.
 
         Args:
             repo_id (str): The name of the repository on the model hub to upload to.

--- a/src/adapters/utils.py
+++ b/src/adapters/utils.py
@@ -53,6 +53,7 @@ ADAPTERFUSION_WEIGHTS_NAME = "pytorch_model_adapter_fusion.bin"
 SAFE_ADAPTERFUSION_WEIGHTS_NAME = "model_adapter_fusion.safetensors"
 EMBEDDING_FILE = "embedding.pt"
 TOKENIZER_PATH = "tokenizer"
+SETUP_CONFIG_NAME = "adapter_setup.json"
 
 ADAPTER_HUB_URL = "https://raw.githubusercontent.com/Adapter-Hub/Hub/master/dist/v2/"
 ADAPTER_HUB_INDEX_FILE = ADAPTER_HUB_URL + "index/{}.json"
@@ -671,6 +672,7 @@ def resolve_adapter_path(
     model_name: str = None,
     adapter_config: Union[dict, str] = None,
     version: str = None,
+    do_exists_check: bool = True,
     **kwargs,
 ) -> str:
     """
@@ -701,8 +703,13 @@ def resolve_adapter_path(
     # path to a local folder saved using save()
     elif isdir(adapter_name_or_path):
         if (
-            isfile(join(adapter_name_or_path, WEIGHTS_NAME)) or isfile(join(adapter_name_or_path, SAFE_WEIGHTS_NAME))
-        ) and isfile(join(adapter_name_or_path, CONFIG_NAME)):
+            not do_exists_check
+            or (
+                isfile(join(adapter_name_or_path, WEIGHTS_NAME))
+                or isfile(join(adapter_name_or_path, SAFE_WEIGHTS_NAME))
+            )
+            and isfile(join(adapter_name_or_path, CONFIG_NAME))
+        ):
             return adapter_name_or_path
         else:
             raise EnvironmentError(

--- a/tests/methods/test_adapter_common.py
+++ b/tests/methods/test_adapter_common.py
@@ -480,6 +480,8 @@ class BottleneckAdapterTestMixin(AdapterMethodBaseTestMixin):
         self.assertFalse(base_with_change)
 
     def test_load_adapter_setup(self):
+        if self.config_class not in ADAPTER_MODEL_MAPPING:
+            self.skipTest("Does not support flex heads.")
         model1, model2 = create_twin_models(self.model_class, self.config)
 
         # Create a complex setup

--- a/tests/methods/test_adapter_common.py
+++ b/tests/methods/test_adapter_common.py
@@ -1,4 +1,5 @@
 import copy
+import os
 import tempfile
 
 import torch
@@ -17,8 +18,10 @@ from adapters import (
     MAMConfig,
     SeqBnConfig,
     SeqBnInvConfig,
+    Stack,
 )
 from adapters.heads.language_modeling import CausalLMHead
+from adapters.utils import SETUP_CONFIG_NAME
 from transformers import MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING, CLIPConfig
 from transformers.testing_utils import require_torch, torch_device
 
@@ -475,3 +478,41 @@ class BottleneckAdapterTestMixin(AdapterMethodBaseTestMixin):
                 base_with_change |= not torch.equal(v1, v2)
         self.assertTrue(adapters_with_change)
         self.assertFalse(base_with_change)
+
+    def test_load_adapter_setup(self):
+        model1, model2 = create_twin_models(self.model_class, self.config)
+
+        # Create a complex setup
+        model1.add_adapter("a", config=SeqBnConfig())
+        model1.add_adapter("b", config=SeqBnConfig())
+        model1.add_adapter("c", config=SeqBnConfig())
+        model1.add_adapter_fusion(["a", "b"])
+        self.add_head(model1, "head_a")
+        self.add_head(model1, "head_b")
+        adapter_setup = Stack(Fuse("a", "b"), "c")
+        head_setup = BatchSplit("head_a", "head_b", batch_sizes=[2, 1])
+        model1.set_active_adapters(adapter_setup)
+        model1.active_head = head_setup
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            model1.save_adapter_setup(temp_dir, adapter_setup, head_setup=head_setup)
+
+            self.assertTrue(os.path.exists(os.path.join(temp_dir, SETUP_CONFIG_NAME)))
+
+            # also tests that set_active works
+            model2.load_adapter_setup(temp_dir, set_active=True)
+
+        # check if adapter was correctly loaded
+        for name in ["a", "b", "c"]:
+            self.assertTrue(name in model2.adapters_config)
+        self.assertEqual(adapter_setup, model2.active_adapters)
+
+        # check equal output
+        input_data = self.get_input_samples(config=model1.config)
+        model1.to(torch_device)
+        model2.to(torch_device)
+        output1 = model1(**input_data)
+        output2 = model2(**input_data)
+        self.assertEqual(len(output1), len(output2))
+        self.assertTrue(torch.allclose(output1[0][0], output2[0][0], atol=1e-4))
+        self.assertTrue(torch.allclose(output1[1][0], output2[1][0], atol=1e-4))

--- a/tests/test_clip.py
+++ b/tests/test_clip.py
@@ -225,3 +225,6 @@ class CLIPAdapterTest(
     def test_adapter_fusion_save_with_head(self):
         # This test is not applicable to CLIP
         self.skipTest("Not applicable to CLIP.")
+
+    def test_load_adapter_setup(self):
+        self.skipTest("Not applicable to CLIP.")


### PR DESCRIPTION
Closes #441; closes #747.

This PR introduces a set of new methods for saving, loading and pushing entire adapter compositions with one command:
- `save_adapter_setup()`
- `load_adapter_setup()`
- `push_adapter_setup_to_hub()`

They require two main params:
- `adapter_setup`: the adapter composition to be saved. Identical to what can be specified for `active_adapters`
- `head_setup`: for models with heads, the head setup to save along with the adapters. Identical to what can be specified for `active_head`

Docs [here](https://github.com/adapter-hub/adapters/blob/04e69957a2bfc8093e2593186f7ebb2e71f88ec9/docs/loading.md#saving-and-loading-adapter-compositions)

### Example

```python
model = AutoAdapterModel.from_pretrained("roberta-base")

# create a complex setup
model.add_adapter("a", config=SeqBnConfig())
model.add_adapter("b", config=SeqBnConfig())
model.add_adapter("c", config=SeqBnConfig())
model.add_adapter_fusion(["a", "b"])
model.add_classification_head("head_a")
model.add_classification_head("head_b")
adapter_setup = Stack(Fuse("a", "b"), "c")
head_setup = BatchSplit("head_a", "head_b", batch_sizes=[1, 1])
model.set_active_adapters(adapter_setup)
model.active_head = head_setup

# save
model.save_adapter_setup("checkpoint", adapter_setup, head_setup=head_setup)

# push
model.push_adapter_setup_to_hub("calpt/random_adapter_setup_test", adapter_setup, head_setup=head_setup)

# re-load
# model2 = AutoAdapterModel.from_pretrained("roberta-base")
# model2.load_adapter_setup("checkpoint", set_active=True)
```
