### PR TITLE
Readme & test fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ A Unified Library for Parameter-Efficient and Modular Transfer Learning
     <a href="https://arxiv.org/abs/2311.11077">Paper</a>
 </h3>
 
-![Tests](https://github.com/Adapter-Hub/adapters/workflows/Tests/badge.svg?branch=adapters)
+![Tests](https://github.com/Adapter-Hub/adapters/workflows/Tests/badge.svg)
 [![GitHub](https://img.shields.io/github/license/adapter-hub/adapters.svg?color=blue)](https://github.com/adapter-hub/adapters/blob/main/LICENSE)
 [![PyPI](https://img.shields.io/pypi/v/adapters)](https://pypi.org/project/adapters/)
 
@@ -45,7 +45,7 @@ _Adapters_ provides a unified interface for efficient fine-tuning and modular tr
 
 ## Installation
 
-`adapters` currently supports **Python 3.8+** and **PyTorch 1.10+**.
+`adapters` currently supports **Python 3.9+** and **PyTorch 2.0+**.
 After [installing PyTorch](https://pytorch.org/get-started/locally/), you can install `adapters` from PyPI ...
 
 ```
@@ -147,7 +147,7 @@ Currently, adapters integrates all architectures and methods listed below:
 
 | Method | Paper(s) | Quick Links |
 | --- | --- | --- |
-| Bottleneck adapters | [Houlsby et al. (2019)](https://arxiv.org/pdf/1902.00751.pdf)<br> [Bapna and Firat (2019)](https://arxiv.org/pdf/1909.08478.pdf) | [Quickstart](https://docs.adapterhub.ml/quickstart.html), [Notebook](https://colab.research.google.com/github/Adapter-Hub/adapters/blob/main/notebooks/01_Adapter_Training.ipynb) |
+| Bottleneck adapters | [Houlsby et al. (2019)](https://arxiv.org/pdf/1902.00751.pdf)<br> [Bapna and Firat (2019)](https://arxiv.org/pdf/1909.08478.pdf)<br> [Steitz and Roth (2024)](https://openaccess.thecvf.com/content/CVPR2024/papers/Steitz_Adapters_Strike_Back_CVPR_2024_paper.pdf) | [Quickstart](https://docs.adapterhub.ml/quickstart.html), [Notebook](https://colab.research.google.com/github/Adapter-Hub/adapters/blob/main/notebooks/01_Adapter_Training.ipynb) |
 | AdapterFusion | [Pfeiffer et al. (2021)](https://aclanthology.org/2021.eacl-main.39.pdf) | [Docs: Training](https://docs.adapterhub.ml/training.html#train-adapterfusion), [Notebook](https://colab.research.google.com/github/Adapter-Hub/adapters/blob/main/notebooks/03_Adapter_Fusion.ipynb) |
 | MAD-X,<br> Invertible adapters | [Pfeiffer et al. (2020)](https://aclanthology.org/2020.emnlp-main.617/) | [Notebook](https://colab.research.google.com/github/Adapter-Hub/adapters/blob/main/notebooks/04_Cross_Lingual_Transfer.ipynb) |
 | AdapterDrop | [Rücklé et al. (2021)](https://arxiv.org/pdf/2010.11918.pdf) | [Notebook](https://colab.research.google.com/github/Adapter-Hub/adapters/blob/main/notebooks/05_Adapter_Drop_Training.ipynb) |

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,7 +1,7 @@
 # Installation
 
 The `adapters` package is designed as an add-on for Hugging Face's Transformers library.
-It currently supports Python 3.8+ and PyTorch 1.10+. You will have to [install PyTorch](https://pytorch.org/get-started/locally/) first. 
+It currently supports Python 3.9+ and PyTorch 2.0+. You will have to [install PyTorch](https://pytorch.org/get-started/locally/) first. 
 
 ```{eval-rst}
 .. important::

--- a/setup.py
+++ b/setup.py
@@ -155,7 +155,7 @@ setup(
     packages=find_packages("src"),
     zip_safe=False,
     extras_require=extras,
-    python_requires=">=3.8.0",
+    python_requires=">=3.9.0",
     install_requires=install_requires,
     classifiers=[
         "Development Status :: 5 - Production/Stable",

--- a/src/adapters/loading.py
+++ b/src/adapters/loading.py
@@ -160,10 +160,10 @@ class WeightsLoaderHelper:
                 else:
                     logger.info(f"No safetensors file found in {save_directory}. Falling back to torch.load...")
                     weights_file = join(save_directory, self.weights_name)
-                    state_dict = torch.load(weights_file, map_location="cpu")
+                    state_dict = torch.load(weights_file, map_location="cpu", weights_only=True)
             else:
                 weights_file = join(save_directory, self.weights_name)
-                state_dict = torch.load(weights_file, map_location="cpu")
+                state_dict = torch.load(weights_file, map_location="cpu", weights_only=True)
         except Exception:
             raise OSError("Unable to load weights from pytorch checkpoint file. ")
         logger.info("Loading module weights from {}".format(weights_file))

--- a/src/adapters/model_mixin.py
+++ b/src/adapters/model_mixin.py
@@ -257,7 +257,7 @@ class EmbeddingAdaptersMixin:
         embedding_path = os.path.join(path, EMBEDDING_FILE)
         if not os.path.isfile(embedding_path):
             raise FileNotFoundError("No embeddings found at {}".format(embedding_path))
-        weights = torch.load(embedding_path)
+        weights = torch.load(embedding_path, weights_only=True)
 
         self.loaded_embeddings[name] = nn.Embedding.from_pretrained(weights)
         self.set_active_embeddings(name)

--- a/src/adapters/trainer.py
+++ b/src/adapters/trainer.py
@@ -41,6 +41,7 @@ class AdapterTrainer(Trainer):
         data_collator: Optional[DataCollator] = None,
         train_dataset: Optional[Union[Dataset, IterableDataset, "datasets.Dataset"]] = None,
         eval_dataset: Optional[Union[Dataset, Dict[str, Dataset], "datasets.Dataset"]] = None,
+        tokenizer: Optional[PreTrainedTokenizerBase] = None,
         processing_class: Optional[
             Union[PreTrainedTokenizerBase, BaseImageProcessor, FeatureExtractionMixin, ProcessorMixin]
         ] = None,
@@ -61,7 +62,7 @@ class AdapterTrainer(Trainer):
             data_collator,
             train_dataset,
             eval_dataset,
-            processing_class=processing_class,
+            processing_class=processing_class or tokenizer,
             model_init=model_init,
             compute_metrics=compute_metrics,
             callbacks=[AdapterTrainerCallback(self)] + callbacks if callbacks else [AdapterTrainerCallback(self)],

--- a/src/adapters/trainer.py
+++ b/src/adapters/trainer.py
@@ -41,18 +41,16 @@ class AdapterTrainer(Trainer):
         data_collator: Optional[DataCollator] = None,
         train_dataset: Optional[Union[Dataset, IterableDataset, "datasets.Dataset"]] = None,
         eval_dataset: Optional[Union[Dataset, Dict[str, Dataset], "datasets.Dataset"]] = None,
-        tokenizer: Optional[PreTrainedTokenizerBase] = None,
         processing_class: Optional[
             Union[PreTrainedTokenizerBase, BaseImageProcessor, FeatureExtractionMixin, ProcessorMixin]
         ] = None,
         model_init: Optional[Callable[[], PreTrainedModel]] = None,
-        compute_loss_func: Optional[Callable] = None,
         compute_metrics: Optional[Callable[[EvalPrediction], Dict]] = None,
         callbacks: Optional[List[TrainerCallback]] = None,
         optimizers: Tuple[Optional[torch.optim.Optimizer], Optional[torch.optim.lr_scheduler.LambdaLR]] = (None, None),
-        optimizer_cls_and_kwargs: Optional[Tuple[Type[torch.optim.Optimizer], Dict[str, Any]]] = None,
         preprocess_logits_for_metrics: Optional[Callable[[torch.Tensor, torch.Tensor], torch.Tensor]] = None,
         adapter_names: Optional[List[List[str]]] = None,
+        **kwargs,
     ):
         if model is not None:
             model_quantized = getattr(model, "is_quantized", False)
@@ -71,6 +69,7 @@ class AdapterTrainer(Trainer):
             optimizers=optimizers,
             optimizer_cls_and_kwargs=optimizer_cls_and_kwargs,
             preprocess_logits_for_metrics=preprocess_logits_for_metrics,
+            **kwargs,
         )
         if model is not None:
             model.is_quantized = model_quantized

--- a/src/adapters/trainer.py
+++ b/src/adapters/trainer.py
@@ -1,6 +1,6 @@
 import os
 import re
-from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
+from typing import Callable, Dict, List, Optional, Tuple, Union
 
 import torch
 from torch import nn
@@ -61,13 +61,11 @@ class AdapterTrainer(Trainer):
             data_collator,
             train_dataset,
             eval_dataset,
-            processing_class=processing_class or tokenizer,
+            processing_class=processing_class,
             model_init=model_init,
-            compute_loss_func=compute_loss_func,
             compute_metrics=compute_metrics,
             callbacks=[AdapterTrainerCallback(self)] + callbacks if callbacks else [AdapterTrainerCallback(self)],
             optimizers=optimizers,
-            optimizer_cls_and_kwargs=optimizer_cls_and_kwargs,
             preprocess_logits_for_metrics=preprocess_logits_for_metrics,
             **kwargs,
         )

--- a/tests/composition/test_parallel.py
+++ b/tests/composition/test_parallel.py
@@ -214,7 +214,7 @@ class ParallelTrainingMixin:
             do_train=True,
             learning_rate=1.0,
             max_steps=20,
-            no_cuda=True,
+            use_cpu=True,
             remove_unused_columns=False,
         )
 

--- a/tests/extended/test_adapter_trainer_ext.py
+++ b/tests/extended/test_adapter_trainer_ext.py
@@ -300,7 +300,7 @@ class TestTrainerExt(TestCasePlus):
             --per_device_eval_batch_size 4
             --max_eval_samples 8
             --val_max_target_length {max_len}
-            --evaluation_strategy steps
+            --eval_strategy steps
             --eval_steps {str(eval_steps)}
             --train_adapter
         """.split()

--- a/tests/methods/base.py
+++ b/tests/methods/base.py
@@ -192,11 +192,11 @@ class AdapterMethodBaseTestMixin:
         name = "dummy_adapter"
         model1.add_adapter(name, config=adapter_config)
         model1.set_active_adapters(name)
-        with tempfile.TemporaryDirectory() as temp_dir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
             model1.save_adapter(temp_dir, name)
 
             # Check that there are actually weights saved
-            weights = torch.load(os.path.join(temp_dir, WEIGHTS_NAME), map_location="cpu")
+            weights = torch.load(os.path.join(temp_dir, WEIGHTS_NAME), map_location="cpu", weights_only=True)
             self.assertTrue(len(weights) > 0)
 
             # also tests that set_active works
@@ -225,7 +225,7 @@ class AdapterMethodBaseTestMixin:
 
         name = "dummy"
         model1.add_adapter(name, config=adapter_config)
-        with tempfile.TemporaryDirectory() as temp_dir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
             model1.save_pretrained(temp_dir)
 
             model2, loading_info = load_model(temp_dir, self.model_class, output_loading_info=True)
@@ -256,7 +256,7 @@ class AdapterMethodBaseTestMixin:
             do_train=True,
             learning_rate=lr,
             max_steps=steps,
-            no_cuda=True,
+            use_cpu=True,
             per_device_train_batch_size=2,
             remove_unused_columns=False,
         )

--- a/tests/test_adapter_conversion.py
+++ b/tests/test_adapter_conversion.py
@@ -37,7 +37,7 @@ class ModelClassConversionTestMixin:
         ):
             self.skipTest("Skipping as base model classes are different.")
 
-        with tempfile.TemporaryDirectory() as temp_dir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
             static_model.save_head(temp_dir)
 
             loading_info = {}
@@ -193,7 +193,7 @@ class ModelClassConversionTestMixin:
         static_model.eval()
         flex_model.eval()
 
-        with tempfile.TemporaryDirectory() as temp_dir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
             static_model.save_adapter(temp_dir, "dummy")
 
             loading_info = {}
@@ -209,7 +209,7 @@ class ModelClassConversionTestMixin:
         model_gen = static_model.generate(**input_samples)
         flex_model_gen = flex_model.generate(**input_samples)
 
-        self.assertEquals(model_gen.shape, flex_model_gen.shape)
+        self.assertEqual(model_gen.shape, flex_model_gen.shape)
         self.assertTrue(torch.equal(model_gen, flex_model_gen))
 
     def test_full_model_conversion(self):
@@ -220,7 +220,7 @@ class ModelClassConversionTestMixin:
         adapters.init(static_head_model)
         static_head_model.eval()
 
-        with tempfile.TemporaryDirectory() as temp_dir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
             static_head_model.save_pretrained(temp_dir)
 
             flex_head_model, loading_info = AutoAdapterModel.from_pretrained(temp_dir, output_loading_info=True)

--- a/tests/test_adapter_embeddings.py
+++ b/tests/test_adapter_embeddings.py
@@ -105,7 +105,7 @@ class EmbeddingTestMixin:
             do_train=True,
             learning_rate=0.4,
             max_steps=15,
-            no_cuda=True,
+            use_cpu=True,
             per_device_train_batch_size=2,
             label_names=["labels"],
         )

--- a/tests/test_adapter_fusion_common.py
+++ b/tests/test_adapter_fusion_common.py
@@ -126,7 +126,7 @@ class AdapterFusionModelTestMixin:
         model1.add_adapter(name2)
         model1.add_adapter_fusion([name1, name2])
         # save & reload model
-        with tempfile.TemporaryDirectory() as temp_dir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
             model1.save_pretrained(temp_dir)
 
             model2 = load_model(temp_dir, self.model_class)

--- a/tests/test_adapter_heads.py
+++ b/tests/test_adapter_heads.py
@@ -315,7 +315,7 @@ class PredictionHeadModelTestMixin:
         self.add_head(model, "dummy", layers=1)
 
         true_config = model.get_prediction_heads_config()
-        with tempfile.TemporaryDirectory() as temp_dir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
             # save
             model.save_pretrained(temp_dir)
             # reload

--- a/tests/test_adapter_hub.py
+++ b/tests/test_adapter_hub.py
@@ -76,7 +76,7 @@ class AdapterHubTest(unittest.TestCase):
                     overwrite_cache=True,
                 )
                 eval_dataset = GlueDataset(data_args, tokenizer=tokenizer, mode="dev")
-                training_args = TrainingArguments(output_dir="./examples", no_cuda=True)
+                training_args = TrainingArguments(output_dir="./examples", use_cpu=True)
 
                 # evaluate
                 trainer = Trainer(

--- a/tests/test_adapter_trainer.py
+++ b/tests/test_adapter_trainer.py
@@ -237,7 +237,7 @@ class TestAdapterTrainer(unittest.TestCase):
                 save_steps=1,
                 remove_unused_columns=False,
                 load_best_model_at_end=True,
-                evaluation_strategy="epoch",
+                eval_strategy="epoch",
                 save_strategy="epoch",
                 num_train_epochs=2,
             )
@@ -273,7 +273,7 @@ class TestAdapterTrainer(unittest.TestCase):
                 save_steps=1,
                 remove_unused_columns=False,
                 load_best_model_at_end=True,
-                evaluation_strategy="epoch",
+                eval_strategy="epoch",
                 save_strategy="epoch",
                 num_train_epochs=2,
             )
@@ -309,7 +309,7 @@ class TestAdapterTrainer(unittest.TestCase):
                 save_steps=1,
                 remove_unused_columns=False,
                 load_best_model_at_end=True,
-                evaluation_strategy="epoch",
+                eval_strategy="epoch",
                 save_strategy="epoch",
                 num_train_epochs=2,
             )
@@ -600,7 +600,7 @@ class TestAdapterTrainer(unittest.TestCase):
                 output_dir=tempdir,
                 per_device_train_batch_size=1,
                 per_device_eval_batch_size=1,
-                evaluation_strategy="steps",
+                eval_strategy="steps",
                 logging_steps=10,
                 max_steps=5,
                 lr_scheduler_type="constant",


### PR DESCRIPTION
Changes in this PR:
- set minimum supported Python version to 3.9 (following recent Transformers upgrade)
- reduce number of warnings in tests
- add `ignore_cleanup_errors=True` in full model loading tests to allow running on Windows
- minor fixes in Readme