### PR TITLE
Wrap ForwardContext around full model forward

### DIFF
--- a/src/adapters/context.py
+++ b/src/adapters/context.py
@@ -106,6 +106,9 @@ class ForwardContext(ContextManager):
         ForwardContext.get_contexts().pop()
 
     def _call_forward(self, model, f, *args, **kwargs):
+        """
+        Calls the forward function of the model with the given arguments and keyword arguments.
+        """
         kwargs = {k: v for k, v in kwargs.items() if k not in self.context_args}
         results = f(model, *args, **kwargs)
 
@@ -123,6 +126,10 @@ class ForwardContext(ContextManager):
 
     @classmethod
     def wrap_base(cls, f):
+        """
+        Decorator method that wraps a ``forward()`` function of a base model class.
+        Unlike ``wrap()``, this method does not create a new context if the is an existing one.
+        """
 
         @functools.wraps(f)
         def wrapper_func(self, *args, **kwargs):

--- a/src/adapters/context.py
+++ b/src/adapters/context.py
@@ -79,15 +79,15 @@ class ForwardContext(ContextManager):
     # thread-local storage that holds a stack of active contexts
     storage = threading.local()
 
-    context_args = [
+    context_args = {
         "output_adapter_gating_scores",
         "output_adapter_fusion_attentions",
         "adapter_input_parallelized",
-    ]
-    context_attributes = [
+    }
+    context_attributes = {
         "adapter_gating_scores",
         "adapter_fusion_attentions",
-    ]
+    }
     # Additional used attributes not exposed to the user
     # - prompt_tokens_length: length of the prompt tokens
 

--- a/src/adapters/context.py
+++ b/src/adapters/context.py
@@ -79,16 +79,22 @@ class ForwardContext(ContextManager):
     # thread-local storage that holds a stack of active contexts
     storage = threading.local()
 
+    context_args = [
+        "output_adapter_gating_scores",
+        "output_adapter_fusion_attentions",
+        "adapter_input_parallelized",
+    ]
     context_attributes = [
         "adapter_gating_scores",
         "adapter_fusion_attentions",
-        "adapter_input_parallelized",
     ]
     # Additional used attributes not exposed to the user
     # - prompt_tokens_length: length of the prompt tokens
 
     def __init__(self, model, *args, **kwargs):
         # If the model has a method ``forward_context()``, use it to create the context.
+        for arg_name in self.context_args:
+            setattr(self, arg_name, kwargs.pop(arg_name, None))
         if hasattr(model, "forward_context"):
             model.forward_context(self, *args, **kwargs)
 
@@ -98,6 +104,36 @@ class ForwardContext(ContextManager):
 
     def __exit__(self, type, value, traceback):
         ForwardContext.get_contexts().pop()
+
+    def _call_forward(self, model, f, *args, **kwargs):
+        kwargs = {k: v for k, v in kwargs.items() if k not in self.context_args}
+        results = f(model, *args, **kwargs)
+
+        # append output attributes
+        if isinstance(results, tuple):
+            for attr in self.context_attributes:
+                if getattr(self, "output_" + attr, False):
+                    results = results + (dict(getattr(self, attr)),)
+        else:
+            for attr in self.context_attributes:
+                if getattr(self, "output_" + attr, False):
+                    results[attr] = dict(getattr(self, attr))
+
+        return results
+
+    @classmethod
+    def wrap_base(cls, f):
+
+        @functools.wraps(f)
+        def wrapper_func(self, *args, **kwargs):
+            if self.adapters_config is not None and ForwardContext.get_context() is None:
+                with cls(self, *args, **kwargs) as ctx:
+                    results = ctx._call_forward(self, f, *args, **kwargs)
+                return results
+            else:
+                return f(self, *args, **kwargs)
+
+        return wrapper_func
 
     @classmethod
     def wrap(cls, f):
@@ -109,30 +145,8 @@ class ForwardContext(ContextManager):
         def wrapper_func(self, *args, **kwargs):
             if self.adapters_config is not None:
                 with cls(self, *args, **kwargs) as ctx:
-                    # whether to output the context attributes
-                    output_context = kwargs.pop("output_context", False)
-                    kwargs = {
-                        k: v for k, v in kwargs.items() if k.replace("output_", "") not in cls.context_attributes
-                    }
-                    results = f(self, *args, **kwargs)
-
-                    # append output attributes
-                    if isinstance(results, tuple):
-                        for attr in cls.context_attributes:
-                            if getattr(ctx, "output_" + attr, False):
-                                results = results + (dict(getattr(ctx, attr)),)
-                    else:
-                        for attr in cls.context_attributes:
-                            if getattr(ctx, "output_" + attr, False):
-                                results[attr] = dict(getattr(ctx, attr))
-
-                    if output_context:
-                        context_dict = ctx.__dict__
-
-                if output_context:
-                    return results, context_dict
-                else:
-                    return results
+                    results = ctx._call_forward(self, f, *args, **kwargs)
+                return results
             else:
                 return f(self, *args, **kwargs)
 

--- a/src/adapters/heads/model_mixin.py
+++ b/src/adapters/heads/model_mixin.py
@@ -584,8 +584,12 @@ class ModelWithFlexibleHeadsAdaptersMixin(ModelWithHeadsAdaptersMixin):
                 kwargs["invertible_adapter"] = inv_adapter
 
         # Set prompt tokens length
+        context = context or ForwardContext.get_context()
         if context is not None:
-            prompt_tokens_length = context.get("prompt_tokens_length", None)
+            if isinstance(context, ForwardContext):
+                prompt_tokens_length = getattr(context, "prompt_tokens_length", None)
+            else:
+                prompt_tokens_length = context.get("prompt_tokens_length", None)
             if prompt_tokens_length is not None:
                 kwargs["prompt_tokens_length"] = prompt_tokens_length
 

--- a/src/adapters/model_mixin.py
+++ b/src/adapters/model_mixin.py
@@ -1703,7 +1703,6 @@ class ModelBaseAdaptersMixin(ModelAdaptersMixin):
 
     @ForwardContext.wrap_base
     def forward(self, *args, **kwargs):
-        print("base context: ", ForwardContext.get_context().__dict__)
         return super().forward(*args, **kwargs)
 
 
@@ -2245,5 +2244,4 @@ class ModelWithHeadsAdaptersMixin(ModelAdaptersMixin):
 
     @ForwardContext.wrap
     def forward(self, *args, **kwargs):
-        print("head context: ", ForwardContext.get_context().__dict__)
         return super().forward(*args, **kwargs)

--- a/src/adapters/model_mixin.py
+++ b/src/adapters/model_mixin.py
@@ -1138,8 +1138,7 @@ class ModelAdaptersMixin(PushAdapterToHubMixin, ABC):
 
         context.adapters_parallelized = False
         # Check if already parallelized in encoder
-        adapter_input_parallelized = kwargs.pop("adapter_input_parallelized", None)
-        if adapter_input_parallelized:
+        if context.adapter_input_parallelized:
             if active_adapters.parallel_channels > 1:
                 context.adapters_parallelized = True
         # Add the shared parameters for the active adapters to the context
@@ -1165,8 +1164,6 @@ class ModelAdaptersMixin(PushAdapterToHubMixin, ABC):
             context.offsets = attention_mask.argmax(1)
 
         # Adapter gating and attention outputs
-        context.output_adapter_gating_scores = kwargs.get("output_adapter_gating_scores", False)
-        context.output_adapter_fusion_attentions = kwargs.get("output_adapter_fusion_attentions", False)
         context.adapter_gating_scores = defaultdict(dict)
         context.adapter_fusion_attentions = defaultdict(dict)
 
@@ -1704,8 +1701,9 @@ class ModelBaseAdaptersMixin(ModelAdaptersMixin):
 
         return embedding_output
 
-    @ForwardContext.wrap
+    @ForwardContext.wrap_base
     def forward(self, *args, **kwargs):
+        print("base context: ", ForwardContext.get_context().__dict__)
         return super().forward(*args, **kwargs)
 
 
@@ -2244,3 +2242,8 @@ class ModelWithHeadsAdaptersMixin(ModelAdaptersMixin):
             else:
                 for p in self.get_output_embeddings().parameters():
                     p.requires_grad = not freeze
+
+    @ForwardContext.wrap
+    def forward(self, *args, **kwargs):
+        print("head context: ", ForwardContext.get_context().__dict__)
+        return super().forward(*args, **kwargs)

--- a/src/adapters/models/albert/adapter_model.py
+++ b/src/adapters/models/albert/adapter_model.py
@@ -6,7 +6,7 @@ from transformers.models.albert.modeling_albert import (
 )
 from transformers.utils import add_start_docstrings, add_start_docstrings_to_model_forward
 
-from ...context import AdapterSetup
+from ...context import AdapterSetup, ForwardContext
 from ...heads import ModelWithFlexibleHeadsAdaptersMixin
 from ...model_mixin import EmbeddingAdaptersWrapperMixin
 from ...wrappers import init
@@ -38,6 +38,7 @@ class AlbertAdapterModel(EmbeddingAdaptersWrapperMixin, ModelWithFlexibleHeadsAd
         self.init_weights()
 
     @add_start_docstrings_to_model_forward(ALBERT_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
+    @ForwardContext.wrap
     def forward(
         self,
         input_ids=None,
@@ -50,8 +51,6 @@ class AlbertAdapterModel(EmbeddingAdaptersWrapperMixin, ModelWithFlexibleHeadsAd
         output_hidden_states=None,
         return_dict=None,
         head=None,
-        output_adapter_gating_scores=False,
-        output_adapter_fusion_attentions=False,
         **kwargs,
     ):
         input_ids = input_ids.view(-1, input_ids.size(-1)) if input_ids is not None else None
@@ -66,7 +65,7 @@ class AlbertAdapterModel(EmbeddingAdaptersWrapperMixin, ModelWithFlexibleHeadsAd
 
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
-        outputs, context = self.albert(
+        outputs = self.albert(
             input_ids,
             attention_mask=attention_mask,
             token_type_ids=token_type_ids,
@@ -76,14 +75,7 @@ class AlbertAdapterModel(EmbeddingAdaptersWrapperMixin, ModelWithFlexibleHeadsAd
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
-            output_adapter_gating_scores=output_adapter_gating_scores,
-            output_adapter_fusion_attentions=output_adapter_fusion_attentions,
-            adapter_input_parallelized=kwargs.pop("adapter_input_parallelized", False),
-            output_context=True,
         )
-        # required e.g. for prompt tuning in all models
-        kwargs["context"] = context
-
         # BERT & RoBERTa & ALBERT return the pooled output as second item, we don't need that in these heads
         if not return_dict:
             head_inputs = (outputs[0],) + outputs[2:]

--- a/src/adapters/models/bert/adapter_model.py
+++ b/src/adapters/models/bert/adapter_model.py
@@ -7,7 +7,7 @@ from transformers.models.bert.modeling_bert import (
 )
 from transformers.utils import add_start_docstrings, add_start_docstrings_to_model_forward
 
-from ...context import AdapterSetup
+from ...context import AdapterSetup, ForwardContext
 from ...heads import ModelWithFlexibleHeadsAdaptersMixin
 from ...model_mixin import EmbeddingAdaptersWrapperMixin
 from ...wrappers import init
@@ -43,6 +43,7 @@ class BertAdapterModel(
         self.init_weights()
 
     @add_start_docstrings_to_model_forward(BERT_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
+    @ForwardContext.wrap
     def forward(
         self,
         input_ids=None,
@@ -55,8 +56,6 @@ class BertAdapterModel(
         output_hidden_states=None,
         return_dict=None,
         head=None,
-        output_adapter_gating_scores=False,
-        output_adapter_fusion_attentions=False,
         **kwargs,
     ):
         input_ids = input_ids.view(-1, input_ids.size(-1)) if input_ids is not None else None
@@ -71,7 +70,7 @@ class BertAdapterModel(
 
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
-        outputs, context = self.bert(
+        outputs = self.bert(
             input_ids,
             attention_mask=attention_mask,
             token_type_ids=token_type_ids,
@@ -81,13 +80,7 @@ class BertAdapterModel(
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
-            output_adapter_gating_scores=output_adapter_gating_scores,
-            output_adapter_fusion_attentions=output_adapter_fusion_attentions,
-            adapter_input_parallelized=kwargs.pop("adapter_input_parallelized", False),
-            output_context=True,
         )
-        # required e.g. for prompt tuning in all models
-        kwargs["context"] = context
         # BERT & RoBERTa return the pooled output as second item, we don't need that in these heads
         if not return_dict:
             head_inputs = (outputs[0],) + outputs[2:]

--- a/src/adapters/models/bert_generation/adapter_model.py
+++ b/src/adapters/models/bert_generation/adapter_model.py
@@ -7,7 +7,7 @@ from transformers.models.bert_generation.modeling_bert_generation import (
 )
 from transformers.utils import add_start_docstrings, add_start_docstrings_to_model_forward
 
-from ...context import AdapterSetup
+from ...context import AdapterSetup, ForwardContext
 from ...heads import ModelWithFlexibleHeadsAdaptersMixin
 from ...model_mixin import EmbeddingAdaptersWrapperMixin
 from ...wrappers import init
@@ -38,6 +38,7 @@ class BertGenerationAdapterModel(
         self.init_weights()
 
     @add_start_docstrings_to_model_forward(BERT_GENERATION_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
+    @ForwardContext.wrap
     def forward(
         self,
         input_ids=None,
@@ -53,8 +54,6 @@ class BertGenerationAdapterModel(
         output_hidden_states=None,
         return_dict=None,
         head=None,
-        output_adapter_gating_scores=False,
-        output_adapter_fusion_attentions=False,
         **kwargs,
     ):
         input_ids = input_ids.view(-1, input_ids.size(-1)) if input_ids is not None else None
@@ -68,7 +67,7 @@ class BertGenerationAdapterModel(
 
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
-        outputs, context = self.bert(
+        outputs = self.bert(
             input_ids,
             attention_mask=attention_mask,
             position_ids=position_ids,
@@ -81,13 +80,7 @@ class BertGenerationAdapterModel(
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
-            output_adapter_gating_scores=output_adapter_gating_scores,
-            output_adapter_fusion_attentions=output_adapter_fusion_attentions,
-            adapter_input_parallelized=kwargs.pop("adapter_input_parallelized", False),
-            output_context=True,
         )
-        # required e.g. for prompt tuning in all models
-        kwargs["context"] = context
         # BERT & RoBERTa return the pooled output as second item, we don't need that in these heads
         if not return_dict:
             head_inputs = (outputs[0],) + outputs[2:]

--- a/src/adapters/models/deberta/adapter_model.py
+++ b/src/adapters/models/deberta/adapter_model.py
@@ -1,7 +1,7 @@
 from transformers.file_utils import add_start_docstrings
 from transformers.models.deberta.modeling_deberta import DebertaModel, DebertaPreTrainedModel
 
-from ...context import AdapterSetup
+from ...context import AdapterSetup, ForwardContext
 from ...heads import ModelWithFlexibleHeadsAdaptersMixin
 from ...model_mixin import EmbeddingAdaptersWrapperMixin
 from ...wrappers import init
@@ -32,6 +32,7 @@ class DebertaAdapterModel(EmbeddingAdaptersWrapperMixin, ModelWithFlexibleHeadsA
 
         self.init_weights()
 
+    @ForwardContext.wrap
     def forward(
         self,
         input_ids=None,
@@ -43,8 +44,6 @@ class DebertaAdapterModel(EmbeddingAdaptersWrapperMixin, ModelWithFlexibleHeadsA
         output_hidden_states=None,
         return_dict=None,
         head=None,
-        output_adapter_gating_scores=False,
-        output_adapter_fusion_attentions=False,
         **kwargs,
     ):
         input_ids = input_ids.view(-1, input_ids.size(-1)) if input_ids is not None else None
@@ -59,7 +58,7 @@ class DebertaAdapterModel(EmbeddingAdaptersWrapperMixin, ModelWithFlexibleHeadsA
 
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
-        outputs, context = self.deberta(
+        outputs = self.deberta(
             input_ids,
             attention_mask=attention_mask,
             token_type_ids=token_type_ids,
@@ -68,13 +67,7 @@ class DebertaAdapterModel(EmbeddingAdaptersWrapperMixin, ModelWithFlexibleHeadsA
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
-            output_adapter_gating_scores=output_adapter_gating_scores,
-            output_adapter_fusion_attentions=output_adapter_fusion_attentions,
-            adapter_input_parallelized=kwargs.pop("adapter_input_parallelized", False),
-            output_context=True,
         )
-        # required e.g. for prompt tuning in all models
-        kwargs["context"] = context
         # BERT & RoBERTa return the pooled output as second item, we don't need that in these heads
         if not return_dict:
             head_inputs = (outputs[0],) + outputs[2:]

--- a/src/adapters/models/deberta_v2/adapter_model.py
+++ b/src/adapters/models/deberta_v2/adapter_model.py
@@ -1,7 +1,7 @@
 from transformers.file_utils import add_start_docstrings
 from transformers.models.deberta_v2.modeling_deberta_v2 import DebertaV2Model, DebertaV2PreTrainedModel
 
-from ...context import AdapterSetup
+from ...context import AdapterSetup, ForwardContext
 from ...heads import ModelWithFlexibleHeadsAdaptersMixin
 from ...model_mixin import EmbeddingAdaptersWrapperMixin
 from ...wrappers import init
@@ -34,6 +34,7 @@ class DebertaV2AdapterModel(
 
         self.init_weights()
 
+    @ForwardContext.wrap
     def forward(
         self,
         input_ids=None,
@@ -45,8 +46,6 @@ class DebertaV2AdapterModel(
         output_hidden_states=None,
         return_dict=None,
         head=None,
-        output_adapter_gating_scores=False,
-        output_adapter_fusion_attentions=False,
         **kwargs,
     ):
         input_ids = input_ids.view(-1, input_ids.size(-1)) if input_ids is not None else None
@@ -61,7 +60,7 @@ class DebertaV2AdapterModel(
 
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
-        outputs, context = self.deberta(
+        outputs = self.deberta(
             input_ids,
             attention_mask=attention_mask,
             token_type_ids=token_type_ids,
@@ -70,13 +69,7 @@ class DebertaV2AdapterModel(
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
-            output_adapter_gating_scores=output_adapter_gating_scores,
-            output_adapter_fusion_attentions=output_adapter_fusion_attentions,
-            adapter_input_parallelized=kwargs.pop("adapter_input_parallelized", False),
-            output_context=True,
         )
-        # required e.g. for prompt tuning in all models
-        kwargs["context"] = context
         # BERT & RoBERTa return the pooled output as second item, we don't need that in these heads
         if not return_dict:
             head_inputs = (outputs[0],) + outputs[2:]

--- a/src/adapters/models/electra/adapter_model.py
+++ b/src/adapters/models/electra/adapter_model.py
@@ -7,7 +7,7 @@ from transformers.models.electra.modeling_electra import (
 )
 from transformers.utils import add_start_docstrings, add_start_docstrings_to_model_forward
 
-from ...context import AdapterSetup
+from ...context import AdapterSetup, ForwardContext
 from ...heads import ModelWithFlexibleHeadsAdaptersMixin
 from ...model_mixin import EmbeddingAdaptersWrapperMixin
 from ...wrappers import init
@@ -43,6 +43,7 @@ class ElectraAdapterModel(
         self.init_weights()
 
     @add_start_docstrings_to_model_forward(ELECTRA_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
+    @ForwardContext.wrap
     def forward(
         self,
         input_ids=None,
@@ -55,8 +56,6 @@ class ElectraAdapterModel(
         output_hidden_states=None,
         return_dict=None,
         head=None,
-        output_adapter_gating_scores=False,
-        output_adapter_fusion_attentions=False,
         **kwargs,
     ):
         input_ids = input_ids.view(-1, input_ids.size(-1)) if input_ids is not None else None
@@ -71,7 +70,7 @@ class ElectraAdapterModel(
 
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
-        outputs, context = self.electra(
+        outputs = self.electra(
             input_ids,
             attention_mask=attention_mask,
             token_type_ids=token_type_ids,
@@ -81,14 +80,7 @@ class ElectraAdapterModel(
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
-            output_adapter_gating_scores=output_adapter_gating_scores,
-            output_adapter_fusion_attentions=output_adapter_fusion_attentions,
-            adapter_input_parallelized=kwargs.pop("adapter_input_parallelized", False),
-            output_context=True,
         )
-        # required e.g. for prompt tuning in all models
-        kwargs["context"] = context
-
         head_inputs = outputs
 
         if head or AdapterSetup.get_context_head_setup() or self.active_head:

--- a/src/adapters/models/gptj/adapter_model.py
+++ b/src/adapters/models/gptj/adapter_model.py
@@ -7,6 +7,7 @@ from transformers.models.gptj.modeling_gptj import GPTJ_START_DOCSTRING, GPTJMod
 from transformers.utils import add_start_docstrings
 
 from ...composition import adjust_tensors_for_parallel
+from ...context import ForwardContext
 from ...heads import ModelWithFlexibleHeadsAdaptersMixin
 from ...model_mixin import EmbeddingAdaptersWrapperMixin
 from ...wrappers import init
@@ -50,6 +51,7 @@ class GPTJAdapterModel(
         self.model_parallel = False
         self.device_map = None
 
+    @ForwardContext.wrap
     def forward(
         self,
         input_ids=None,
@@ -64,13 +66,11 @@ class GPTJAdapterModel(
         output_hidden_states=None,
         return_dict=None,
         head=None,
-        output_adapter_gating_scores=False,
-        output_adapter_fusion_attentions=False,
         **kwargs,
     ):
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
-        outputs, context = self.transformer(
+        outputs = self.transformer(
             input_ids,
             past_key_values=past_key_values,
             attention_mask=attention_mask,
@@ -82,14 +82,7 @@ class GPTJAdapterModel(
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
-            output_adapter_gating_scores=output_adapter_gating_scores,
-            output_adapter_fusion_attentions=output_adapter_fusion_attentions,
-            adapter_input_parallelized=kwargs.pop("adapter_input_parallelized", False),
-            output_context=True,
         )
-        # required e.g. for prompt tuning in all models
-        kwargs["context"] = context
-
         batch_size = outputs[0].shape[0]
 
         if self.config.pad_token_id is None:

--- a/src/adapters/models/plbart/adapter_model.py
+++ b/src/adapters/models/plbart/adapter_model.py
@@ -11,6 +11,7 @@ from transformers.models.plbart.modeling_plbart import (
 )
 from transformers.utils import add_start_docstrings, add_start_docstrings_to_model_forward
 
+from ...context import ForwardContext
 from ...heads import ModelWithFlexibleHeadsAdaptersMixin
 from ...model_mixin import EmbeddingAdaptersWrapperMixin
 from ...wrappers import init
@@ -50,6 +51,7 @@ class PLBartAdapterModel(
         return self.model.get_decoder()
 
     @add_start_docstrings_to_model_forward(PLBART_INPUTS_DOCSTRING)
+    @ForwardContext.wrap
     def forward(
         self,
         input_ids=None,
@@ -68,8 +70,6 @@ class PLBartAdapterModel(
         return_dict=None,
         past_key_values=None,
         head=None,
-        output_adapter_gating_scores=False,
-        output_adapter_fusion_attentions=False,
         **kwargs,
     ):
         r"""
@@ -82,7 +82,7 @@ class PLBartAdapterModel(
         if "labels" in kwargs or "start_positions" in kwargs and "end_positions" in kwargs:
             use_cache = False
 
-        outputs, context = self.model(
+        outputs = self.model(
             input_ids,
             attention_mask=attention_mask,
             decoder_input_ids=decoder_input_ids,
@@ -98,14 +98,7 @@ class PLBartAdapterModel(
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
             past_key_values=past_key_values,
-            output_adapter_gating_scores=output_adapter_gating_scores,
-            output_adapter_fusion_attentions=output_adapter_fusion_attentions,
-            adapter_input_parallelized=kwargs.pop("adapter_input_parallelized", False),
-            output_context=True,
         )
-        # required e.g. for prompt tuning in all models
-        kwargs["context"] = context
-
         head_outputs = self.forward_head(
             outputs,
             head_name=head,

--- a/src/adapters/models/t5/adapter_model.py
+++ b/src/adapters/models/t5/adapter_model.py
@@ -7,6 +7,7 @@ from transformers.models.t5.modeling_t5 import T5_INPUTS_DOCSTRING, T5_START_DOC
 from transformers.utils import add_start_docstrings, add_start_docstrings_to_model_forward
 
 from ...composition import adjust_tensors_for_parallel
+from ...context import ForwardContext
 from ...heads import ModelWithFlexibleHeadsAdaptersMixin, Seq2SeqLMHead
 from ...model_mixin import EmbeddingAdaptersWrapperMixin
 from ...wrappers import init
@@ -56,6 +57,7 @@ class T5AdapterModel(
         return self.transformer.decoder
 
     @add_start_docstrings_to_model_forward(T5_INPUTS_DOCSTRING)
+    @ForwardContext.wrap
     def forward(
         self,
         input_ids=None,
@@ -75,8 +77,6 @@ class T5AdapterModel(
         output_hidden_states=None,
         return_dict=None,
         head=None,
-        output_adapter_gating_scores=False,
-        output_adapter_fusion_attentions=False,
         **kwargs,
     ):
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
@@ -89,7 +89,7 @@ class T5AdapterModel(
                 # decoder_input_ids from input_ids if no decoder_input_ids are provided
                 decoder_input_ids = self._shift_right(input_ids)
 
-        model_output, context = self.transformer(
+        model_output = self.transformer(
             input_ids=input_ids,
             attention_mask=attention_mask,
             decoder_input_ids=decoder_input_ids,
@@ -105,13 +105,7 @@ class T5AdapterModel(
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
-            output_adapter_gating_scores=output_adapter_gating_scores,
-            output_adapter_fusion_attentions=output_adapter_fusion_attentions,
-            adapter_input_parallelized=kwargs.pop("adapter_input_parallelized", False),
-            output_context=True,
         )
-        # required e.g. for prompt tuning in all models
-        kwargs["context"] = context
         sequence_output = model_output[0]
         # ToDo move head to device for parallel forward pass
 

--- a/src/adapters/models/xmod/adapter_model.py
+++ b/src/adapters/models/xmod/adapter_model.py
@@ -11,7 +11,7 @@ from transformers.models.xmod.modeling_xmod import (
 )
 from transformers.utils import add_start_docstrings, add_start_docstrings_to_model_forward
 
-from ...context import AdapterSetup
+from ...context import AdapterSetup, ForwardContext
 from ...heads import ModelWithFlexibleHeadsAdaptersMixin
 from ...model_mixin import EmbeddingAdaptersWrapperMixin
 from ...wrappers import init
@@ -47,6 +47,7 @@ class XmodAdapterModel(
         self.init_weights()
 
     @add_start_docstrings_to_model_forward(XMOD_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
+    @ForwardContext.wrap
     def forward(
         self,
         input_ids: Optional[torch.Tensor] = None,
@@ -60,8 +61,6 @@ class XmodAdapterModel(
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
         head: Optional[str] = None,
-        output_adapter_gating_scores: Optional[bool] = False,
-        output_adapter_fusion_attentions: Optional[bool] = False,
         **kwargs,
     ):
         # Flatten for multiple choice tasks
@@ -78,7 +77,7 @@ class XmodAdapterModel(
 
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
-        outputs, context = self.roberta(
+        outputs = self.roberta(
             input_ids,
             lang_ids=lang_ids,
             attention_mask=attention_mask,
@@ -89,13 +88,7 @@ class XmodAdapterModel(
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
-            output_adapter_gating_scores=output_adapter_gating_scores,
-            output_adapter_fusion_attentions=output_adapter_fusion_attentions,
-            adapter_input_parallelized=kwargs.pop("adapter_input_parallelized", False),
-            output_context=True,
         )
-        # required e.g. for prompt tuning in all models
-        kwargs["context"] = context
         # BERT & RoBERTa return the pooled output as second item, we don't need that in these heads
         if not return_dict:
             head_inputs = (outputs[0],) + outputs[2:]

--- a/src/adapters/wrappers/model.py
+++ b/src/adapters/wrappers/model.py
@@ -85,7 +85,7 @@ def init(model: PreTrainedModel, adapters_config: Optional[ModelAdaptersConfig] 
                 params = list(temp_signature.parameters.values())
                 # add forward context args to signature
                 for param_name in ForwardContext.context_args:
-                    params.append(inspect.Parameter(param_name, inspect.Parameter.VAR_KEYWORD))
+                    params.append(inspect.Parameter(param_name, inspect.Parameter.POSITIONAL_OR_KEYWORD, default=None))
                 temp_signature = temp_signature.replace(parameters=params)
                 # Create new wrapper model class
                 model_class_name = model.__class__.__name__

--- a/src/adapters/wrappers/model.py
+++ b/src/adapters/wrappers/model.py
@@ -10,7 +10,6 @@ from transformers.models.auto.auto_factory import getattribute_from_module
 from transformers.models.auto.configuration_auto import model_type_to_module_name
 
 from ..configuration import ModelAdaptersConfig
-from ..context import ForwardContext
 from ..model_mixin import (
     EmbeddingAdaptersWrapperMixin,
     ModelAdaptersMixin,
@@ -82,11 +81,6 @@ def init(model: PreTrainedModel, adapters_config: Optional[ModelAdaptersConfig] 
             if isinstance(base_model, ModelAdaptersMixin):
                 # HACK to preserve original forward method signature (e.g. for Trainer label names)
                 temp_signature = inspect.signature(model.forward.__func__)
-                params = list(temp_signature.parameters.values())
-                # add forward context args to signature
-                for param_name in ForwardContext.context_args:
-                    params.append(inspect.Parameter(param_name, inspect.Parameter.POSITIONAL_OR_KEYWORD, default=None))
-                temp_signature = temp_signature.replace(parameters=params)
                 # Create new wrapper model class
                 model_class_name = model.__class__.__name__
                 model_class = type(

--- a/src/adapters/wrappers/model.py
+++ b/src/adapters/wrappers/model.py
@@ -85,7 +85,7 @@ def init(model: PreTrainedModel, adapters_config: Optional[ModelAdaptersConfig] 
                 params = list(temp_signature.parameters.values())
                 # add forward context args to signature
                 for param_name in ForwardContext.context_args:
-                    params.append(inspect.Parameter(param_name, inspect.Parameter.KEYWORD_ONLY))
+                    params.append(inspect.Parameter(param_name, inspect.Parameter.VAR_KEYWORD))
                 temp_signature = temp_signature.replace(parameters=params)
                 # Create new wrapper model class
                 model_class_name = model.__class__.__name__


### PR DESCRIPTION
This PR adapts the ForwardContext to be applied to the full model (including head) forward pass. The original base model forward wrapper is now moved to `wrap_base` to make sure no second ForwardContext is created for a single forward pass.

This enables passing custom args that are defined in the ForwardContext definition to the top-level model call, as discussed in #783, e.g.:
```python
model = AutoModelForCausalLM.from_pretrained(model_name)
adapters.init(model)
tokenizer = AutoTokenizer.from_pretrained(model_name)
inputs = tokenizer(["This is a test text"], return_tensors="pt")

# Registers new forward args globally
ForwardContext.context_args.add("task_ids")

# New the new arg name can be used w/o modifying the model's forward method
output = model(**inputs, task_ids=["id_0", "id_1"])
```
In the example above, the forward context will automatically add the passed context args as attributes, ie. they can be accessed within the foward pass like this:
```python
task_ids = ForwardContext.get_context().task_ids
```
