### PR TITLE
Fix `BatchSplit` for `PrefixTuning`

### DIFF
--- a/src/adapters/methods/prefix_tuning.py
+++ b/src/adapters/methods/prefix_tuning.py
@@ -510,7 +510,12 @@ class PrefixTuningLayer(ComposableAdapterLayerBase, nn.Module):
         # Select index range for batch split
         # Ignore slices that go beyond the prefix states bsz
         # (this is the case for slices produced by Parallel blocks which operate on replicated kv states)
-        if state.idx_slice is not None and state.idx_slice.start < prefix_keys.size(0):
+        # But, let pass slices go beyond which return empty tensor
+        # (this is the case for last batch_size == 0 for BatchSplit blocks)
+        if state.idx_slice is not None and (
+            state.idx_slice.start < prefix_keys.size(0)
+            or state.idx_slice.start == state.idx_slice.stop == prefix_keys.size(0)
+        ):
             prefix_keys = prefix_keys[state.idx_slice]
             prefix_values = prefix_values[state.idx_slice]
 

--- a/tests/test_misc/test_adapter_composition.py
+++ b/tests/test_misc/test_adapter_composition.py
@@ -161,8 +161,10 @@ class AdapterCompositionTest(unittest.TestCase):
             self.skipTest("BatchSplit not supported by adapter config.")
 
         model = self.build_model()
-        model.set_active_adapters(BatchSplit("a", "b", "c", batch_sizes=[1, 1, 2]))
-        self.batched_training_pass(model)
+        for batch_sizes in [[1, 1, 2], [2, 0, 2], [2, 2, 0]]:
+            with self.subTest(batch_sizes=batch_sizes):
+                model.set_active_adapters(BatchSplit("a", "b", "c", batch_sizes=batch_sizes))
+                self.batched_training_pass(model)
 
     def test_batch_split_int(self):
         if BatchSplit in self.unsupported_blocks:


### PR DESCRIPTION
> Please refer to #794.  

In `BatchSplit.compose_single`, slicing for `BatchSplit` is not considered when `slice.start` exceeds the input batch size.  
If the last `batch_size` in `BatchSplit.batch_sizes` is `0`, the `start` and `stop` values of `state.idx_slice` are equal to the input batch size. As a result, the input prefix keys and values cannot be sliced into an empty tensor.

Useful for #792 