### PR TITLE
Unlock version of transformers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ _deps = [
     "timeout-decorator",
     "torch",
     "torchvision",
-    "transformers~=4.47.1",
+    "transformers>=4.47.1",
 ]
 
 


### PR DESCRIPTION
Is there any reason why we lock transformers version to 4.47.1 ? This conflicts with many packages, like latest vllm.