### PR TITLE
Adapter Interface: Validate Values

### DIFF
--- a/src/adapters/wrappers/model.py
+++ b/src/adapters/wrappers/model.py
@@ -20,6 +20,7 @@ from ..model_mixin import (
     ModelWithHeadsAdaptersMixin,
 )
 from ..models import MODEL_MIXIN_MAPPING
+from ..utils import multigetattr, multihasattr
 from .configuration import init_adapters_config
 
 
@@ -64,6 +65,7 @@ def init(
 
     if interface is not None:
         base_model = model.base_model
+        _validate_interface_values(base_model, interface)
         model_class_name = base_model.__class__.__name__
         model_class = type(
             model_class_name,
@@ -167,3 +169,77 @@ def load_model(
     model = new_model_class.from_pretrained(model_name_or_path, *model_args, **kwargs)
 
     return model
+
+
+def _validate_interface_values(base_model: PreTrainedModel, interface: AdapterModelInterface) -> None:
+    """
+    Validates that all values specified in the interface exist in the model.
+
+    Args:
+        base_model: The base model to validate against
+        interface: The adapter interface to validate
+
+    Raises:
+        ValueError: If any specified path is not found in the model
+    """
+
+    if not multihasattr(base_model, interface.model_embeddings):
+        raise ValueError(
+            f"AdapterInterface: 'model_embeddings' is set to '{interface.model_embeddings}' but this value is not found in the model. See https://docs.adapterhub.ml/plugin_interface.html for more information."
+        )
+
+    # All other values are layer specific => Get the first layer and check if all values are present
+    layers = multigetattr(base_model, interface.model_layers)
+    if not layers:
+        raise ValueError(
+            f"AdapterInterface: 'model_layers' is set to '{interface.model_layers}' but this value is not found in the model. See https://docs.adapterhub.ml/plugin_interface.html for more information."
+        )
+
+    if len(layers) == 0:
+        raise ValueError(
+            f"AdapterInterface: 'model_layers' is set to '{interface.model_layers}' but accessing the value in the model returns an empty list. See https://docs.adapterhub.ml/plugin_interface.html for more information."
+        )
+
+    layer = layers[0]
+
+    layer_attributes = [
+        "layer_self_attn",
+        "layer_cross_attn",
+        "layer_intermediate_proj",
+        "layer_output_proj",
+        "layer_pre_self_attn",
+        "layer_pre_cross_attn",
+        "layer_pre_ffn",
+        "layer_ln_1",
+        "layer_ln_2",
+    ]
+    values_to_check = {
+        name: getattr(interface, name) for name in layer_attributes if getattr(interface, name) is not None
+    }
+
+    for layer_name, layer_value in values_to_check.items():
+        if not multihasattr(layer, layer_value):
+            raise ValueError(
+                f"AdapterInterface: '{layer_name}' is set to '{layer_value}' but this value is not found in the model layer. See https://docs.adapterhub.ml/plugin_interface.html for more information."
+            )
+
+    # Check attention-specific attributes if self-attention or cross-attention is defined
+    attention_attributes = ["attn_q_proj", "attn_k_proj", "attn_v_proj", "attn_o_proj"]
+
+    if interface.layer_self_attn is not None:
+        self_attn_module = multigetattr(layer, interface.layer_self_attn)
+        for attn_name in attention_attributes:
+            attn_value = getattr(interface, attn_name)
+            if not multihasattr(self_attn_module, attn_value):
+                raise ValueError(
+                    f"AdapterInterface: '{attn_name}' is set to '{attn_value}' but this value is not found in the self-attention layer. See https://docs.adapterhub.ml/plugin_interface.html for more information."
+                )
+
+    if interface.layer_cross_attn is not None:
+        cross_attn_module = multigetattr(layer, interface.layer_cross_attn)
+        for attn_name in attention_attributes:
+            attn_value = getattr(interface, attn_name)
+            if not multihasattr(cross_attn_module, attn_value):
+                raise ValueError(
+                    f"AdapterInterface: '{attn_name}' is set to '{attn_value}' but this value is not found in the cross-attention layer. See https://docs.adapterhub.ml/plugin_interface.html for more information."
+                )

--- a/tests/test_methods/test_on_custom_interface.py
+++ b/tests/test_methods/test_on_custom_interface.py
@@ -11,9 +11,9 @@ from transformers.testing_utils import torch_device
 
 from .base import TextAdapterTestBase
 from .generator import generate_method_tests, require_torch
-from .method_test_impl.peft.test_adapter_common import BottleneckAdapterTestMixin
 from .method_test_impl.core.test_adapter_backward_compability import CompabilityTestMixin
 from .method_test_impl.core.test_adapter_fusion_common import AdapterFusionModelTestMixin
+from .method_test_impl.peft.test_adapter_common import BottleneckAdapterTestMixin
 from .method_test_impl.utils import create_twin_models, make_config
 
 


### PR DESCRIPTION
This PR introduces a validation for the values specified in the adapter interfaces. We now check that the layers specified actually exist and if not, we provide a detailed error to the user so that they know what went wrong.

Before this PR, when users specify layers in the adapter interfaces that don't exist in the model, there was no error thrown. This left users unaware that their specified values were invalid.