### PR TITLE
[WIP] ModernBERT & Gemma2; Adapter Interface for Unified QKV Layers

### DIFF
--- a/docs/plugin_interface.md
+++ b/docs/plugin_interface.md
@@ -85,6 +85,12 @@ adapters.init(model, interface=adapter_interface)
 ```
 Now, you can use (almost) all functionality of the _Adapters_ library on the adapted model instance!
 
+
+```{eval-rst}
+.. note::
+    Some models like GPT-2 or ModernBERT have the query, value and key layer in one single tensor. In this case, you must set the `attn_qkv_proj` instead of setting `attn_k_proj`, `attn_q_proj` and `attn_v_proj`.
+```
+
 ## Limitations
 
 The following features of the _Adapters_ library are not supported via the plugin interface approach:

--- a/src/adapters/methods/lora.py
+++ b/src/adapters/methods/lora.py
@@ -829,16 +829,25 @@ class LoRAMergedLinear(LoRALayer, nn.Linear):
 
 def init_lora(model):
     model = model.base_model
+
+    # First, check if we should use merged linear layer instead of individual q,k,v projections
+    use_merged_linear = model.adapter_interface.attn_qkv_proj is not None
+
     for _, _, attention in model.iter_attentions():
-        if q_proj := multigetattr(attention, model.adapter_interface.attn_q_proj, None):
-            lora_proj = LoRALinear.wrap(q_proj, "selfattn", model.config, model.adapters_config, attn_key="q")
-            multisetattr(attention, model.adapter_interface.attn_q_proj, lora_proj)
-        if k_proj := multigetattr(attention, model.adapter_interface.attn_k_proj, None):
-            lora_proj = LoRALinear.wrap(k_proj, "selfattn", model.config, model.adapters_config, attn_key="k")
-            multisetattr(attention, model.adapter_interface.attn_k_proj, lora_proj)
-        if v_proj := multigetattr(attention, model.adapter_interface.attn_v_proj, None):
-            lora_proj = LoRALinear.wrap(v_proj, "selfattn", model.config, model.adapters_config, attn_key="v")
-            multisetattr(attention, model.adapter_interface.attn_v_proj, lora_proj)
+        if use_merged_linear:
+            if qkv_proj := multigetattr(attention, model.adapter_interface.attn_qkv_proj, None):
+                lora_proj = LoRAMergedLinear.wrap(qkv_proj, "selfattn", model.config, model.adapters_config)
+                multisetattr(attention, model.adapter_interface.attn_qkv_proj, lora_proj)
+        else:
+            if q_proj := multigetattr(attention, model.adapter_interface.attn_q_proj, None):
+                lora_proj = LoRALinear.wrap(q_proj, "selfattn", model.config, model.adapters_config, attn_key="q")
+                multisetattr(attention, model.adapter_interface.attn_q_proj, lora_proj)
+            if k_proj := multigetattr(attention, model.adapter_interface.attn_k_proj, None):
+                lora_proj = LoRALinear.wrap(k_proj, "selfattn", model.config, model.adapters_config, attn_key="k")
+                multisetattr(attention, model.adapter_interface.attn_k_proj, lora_proj)
+            if v_proj := multigetattr(attention, model.adapter_interface.attn_v_proj, None):
+                lora_proj = LoRALinear.wrap(v_proj, "selfattn", model.config, model.adapters_config, attn_key="v")
+                multisetattr(attention, model.adapter_interface.attn_v_proj, lora_proj)
 
     for _, layer in model.iter_layers():
         if intermediate_proj := multigetattr(layer, model.adapter_interface.layer_intermediate_proj):

--- a/src/adapters/wrappers/interfaces.py
+++ b/src/adapters/wrappers/interfaces.py
@@ -1,0 +1,48 @@
+from transformers import ModernBertPreTrainedModel, Gemma2PreTrainedModel
+
+from adapters import AdapterModelInterface
+
+CUSTOM_INTERFACES = {
+    ModernBertPreTrainedModel: AdapterModelInterface(
+        adapter_methods=["bottleneck", "lora", "reft", "invertible"],  # not yet working for prompt tuning
+        model_embeddings="embeddings",
+        model_layers="layers",
+        layer_self_attn="attn",
+        layer_cross_attn=None,
+        attn_qkv_proj="Wqkv",
+        attn_o_proj="Wo",
+        layer_intermediate_proj="mlp.Wi",
+        layer_output_proj="mlp.Wo",
+        layer_pre_self_attn="attn",
+        layer_pre_cross_attn=None,
+        layer_pre_ffn="mlp",
+        layer_ln_1="mlp_norm",
+        layer_ln_2=None,  # ModernBERT has no layer norm after the attention layer
+    ),
+    Gemma2PreTrainedModel: AdapterModelInterface(
+        adapter_methods=["bottleneck", "lora", "reft", "invertible"],
+        model_embeddings="embed_tokens",
+        model_layers="layers",
+        layer_self_attn="self_attn",
+        layer_cross_attn=None,
+        attn_k_proj="k_proj",
+        attn_q_proj="q_proj",
+        attn_v_proj="v_proj",
+        attn_o_proj="o_proj",
+        layer_intermediate_proj="mlp.up_proj",
+        layer_output_proj="mlp.down_proj",
+        layer_pre_self_attn="input_layernorm",
+        layer_pre_cross_attn=None,
+        layer_pre_ffn="pre_feedforward_layernorm",
+        layer_ln_1="post_attention_layernorm",
+        layer_ln_2="post_feedforward_layernorm",
+    ),
+}
+
+
+def get_adapter_interface(model):
+    # If it is a sub type of a known model, return the corresponding interface
+    for model_type, interface in CUSTOM_INTERFACES.items():
+        if isinstance(model, model_type):
+            return interface
+    return None

--- a/tests/test_methods/test_all_custom_interfaces.py
+++ b/tests/test_methods/test_all_custom_interfaces.py
@@ -1,0 +1,108 @@
+import os
+import tempfile
+import unittest
+import adapters
+from adapters import LoRAConfig
+from transformers import AutoModel, Gemma2Config, ModernBertConfig
+from transformers.testing_utils import torch_device
+
+from tests.test_methods.method_test_impl.base import AdapterMethodBaseTestMixin
+from .base import TextAdapterTestBase
+
+from adapters import LoRAConfig
+
+
+# To add tests for a new model, add a new entry to this dictionary. Nothing else needs to be changed.
+MODEL_CONFIGS = {
+    "ModernBERT": {
+        "config_class": ModernBertConfig,
+        "config_params": {
+            "hidden_size": 32,
+            "num_hidden_layers": 4,
+            "num_attention_heads": 4,
+            "intermediate_size": 64,
+            "pad_token_id": 0,
+        },
+        "test_base": TextAdapterTestBase,
+    },
+    "Gemma2": {
+        "config_class": Gemma2Config,
+        "config_params": {
+            "hidden_size": 32,
+            "num_hidden_layers": 4,
+            "num_attention_heads": 4,
+            "num_key_value_heads": 4,
+            "intermediate_size": 64,
+            "pad_token_id": 0,
+        },
+        "test_base": TextAdapterTestBase,
+    },
+}
+
+ADAPTER_CONFIGS = {
+    "lora": LoRAConfig(init_weights="bert", intermediate_lora=True, output_lora=True),
+    "reft": "loreft",
+    "bottleneck": "seq_bn",
+    "invertible": "double_seq_bn_inv",
+    "prompt_tuning": "prompt_tuning",
+}
+
+
+class CustomInterfaceTestBase(AdapterMethodBaseTestMixin):
+    """
+    Tests for the custom interfaces we support. This test suite is limited to test the basic functionality only per model to save time.
+    """
+
+    def get_model(self):
+        model = AutoModel.from_config(self.config())
+        adapters.init(model)  # No need to specify interface, it's auto-detected
+        model.to(torch_device)
+        return model
+
+    def test_forward_pass(self):
+        """Test that forward pass works with all supported adapter methods."""
+        model = self.get_model()
+        adapter_methods = model.adapter_interface.adapter_methods
+
+        for method in adapter_methods:
+            with self.subTest(adapter_method=method):
+                self.run_forward_test(model, ADAPTER_CONFIGS[method])
+
+    def test_adapter_loading(self):
+        """Test saving and loading adapters."""
+        model = self.get_model()
+        model.eval()
+
+        # Add and activate adapter
+        name = "test_adapter"
+        model.add_adapter(name, config=LoRAConfig())
+        model.set_active_adapters(name)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Save adapter
+            model.save_adapter(temp_dir, name)
+            # Check that weights file exists
+            self.assertTrue(os.path.exists(os.path.join(temp_dir, "pytorch_adapter.bin")))
+
+            # Load adapter into new model
+            new_model = self.get_model()
+            new_model.load_adapter(temp_dir)
+            self.assertTrue(name in new_model.adapters_config)
+
+
+# Create test classes for each model
+for model_name, model_config in MODEL_CONFIGS.items():
+    # Create model-specific test class
+    test_class = type(
+        model_name,  # This will create classes named "ModernBERT" and "Gemma2"
+        (CustomInterfaceTestBase, model_config["test_base"], unittest.TestCase),  # Include the specified test base
+        {
+            "config_class": model_config["config_class"],
+            "config": staticmethod(
+                lambda params=model_config["config_params"]: model_config["config_class"](**params)
+            ),
+        },
+    )
+
+    # Add test class to global namespace
+    globals()[model_name] = test_class


### PR DESCRIPTION
This PR adds the possibility for _Adapters_ to provide default adapter interfaces. ModernBERT and Gemma2 are now supported out of the box, e.g.:
```python
import adapters
from transformers import AutoModelForMaskedLM 

model = AutoModelForMaskedLM.from_pretrained("answerdotai/ModernBERT-base")  
adapters.init(model)
```

Since ModernBERT uses QKV in one layer like GPT2 and DeBERTa, I added support

TODO:
- [ ] make test file more readable
- [ ] add docs

This solves #779