### PR TITLE
Upgrade Transformers to v4.50.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ _deps = [
     "timeout-decorator",
     "torch",
     "torchvision",
-    "transformers~=4.48.3",
+    "transformers~=4.50.3",
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -142,7 +142,7 @@ install_requires = [
 
 setup(
     name="adapters",
-    version="1.1.0",
+    version="1.2.0.dev0",
     author="The AdapterHub team and community contributors",
     author_email="calpt@mail.de",
     description="A Unified Library for Parameter-Efficient and Modular Transfer Learning",

--- a/src/adapters/__init__.py
+++ b/src/adapters/__init__.py
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.1.0"
+__version__ = "1.2.0.dev0"
 
 from typing import TYPE_CHECKING
 

--- a/src/adapters/head_utils.py
+++ b/src/adapters/head_utils.py
@@ -793,9 +793,9 @@ STATIC_TO_FLEX_HEAD_MAP = {
 
 def _regex_list_rename_func(k, rename_list):
     for o, n in rename_list:
-        new_n, count = re.subn(o, k, n)
+        new_k, count = re.subn(o, n, k)
         if count > 0:
-            return new_n
+            return new_k
     return k
 
 

--- a/src/adapters/head_utils.py
+++ b/src/adapters/head_utils.py
@@ -793,13 +793,13 @@ STATIC_TO_FLEX_HEAD_MAP = {
 
 def _regex_list_rename_func(k, rename_list):
     for o, n in rename_list:
-        match = re.match(o, k)
-        if match:
-            return n.format(match.group(1))
+        new_n, count = re.subn(o, k, n)
+        if count > 0:
+            return new_n
     return k
 
 
-def get_head_config_and_rename_list(model_class_name, head_name, label2id, num_labels=None):
+def get_head_config_and_rename_list(model_class_name, head_name, label2id, num_labels=None, return_rename_func=True):
     if label2id is None:
         logger.warning(
             "No valid map of labels in label2id. Falling back to default (num_labels=2). This may cause errors during"
@@ -823,8 +823,11 @@ def get_head_config_and_rename_list(model_class_name, head_name, label2id, num_l
     for name in data["layers"]:
         if name is not None:
             escaped_name = re.escape(name)
-            rename_list.append((rf"{escaped_name}\.(\S+)", f"heads.{head_name}.{i}.{{0}}"))
+            rename_list.append((rf"{escaped_name}\.(\S+)", f"heads.{head_name}.{i}.\\1"))
         i += 1
-    rename_func = lambda k, rename_list=rename_list: _regex_list_rename_func(k, rename_list)
+    if return_rename_func:
+        rename_func = lambda k, rename_list=rename_list: _regex_list_rename_func(k, rename_list)
 
-    return config, rename_func
+        return config, rename_func
+    else:
+        return config, {k: v for k, v in rename_list}

--- a/src/adapters/heads/model_mixin.py
+++ b/src/adapters/heads/model_mixin.py
@@ -713,25 +713,26 @@ class ModelWithFlexibleHeadsAdaptersMixin(ModelWithHeadsAdaptersMixin):
         key_mapping=None,
         **kwargs,
     ):
-        original_model_class = model.config.architectures[0]
-        head_name = "default"
-        if original_model_class in STATIC_TO_FLEX_HEAD_MAP:
-            head_config, rename_dict = get_head_config_and_rename_list(
-                original_model_class,
-                head_name,
-                getattr(model.config, "label2id"),
-                return_rename_func=False,
-            )
-            # add head from config
-            if head_name in model.heads:
-                logger.warning("Overwriting existing head '{}'".format(head_name))
+        if model.config.architectures is not None:
+            original_model_class = model.config.architectures[0]
+            head_name = "default"
+            if original_model_class in STATIC_TO_FLEX_HEAD_MAP:
+                head_config, rename_dict = get_head_config_and_rename_list(
+                    original_model_class,
+                    head_name,
+                    getattr(model.config, "label2id"),
+                    return_rename_func=False,
+                )
+                # add head from config
+                if head_name in model.heads:
+                    logger.warning("Overwriting existing head '{}'".format(head_name))
 
-            model.add_prediction_head_from_config(head_name, head_config, overwrite_ok=True)
+                model.add_prediction_head_from_config(head_name, head_config, overwrite_ok=True)
 
-            if key_mapping is None:
-                key_mapping = rename_dict
-            else:
-                key_mapping.update(rename_dict)
+                if key_mapping is None:
+                    key_mapping = rename_dict
+                else:
+                    key_mapping.update(rename_dict)
 
         return super()._load_pretrained_model(
             model,

--- a/src/adapters/models/vit/modeling_vit.py
+++ b/src/adapters/models/vit/modeling_vit.py
@@ -16,90 +16,62 @@
 
 
 import math
-from typing import Optional, Tuple, Union
+from typing import Callable, Optional, Tuple, Union
 
 import torch
 import torch.utils.checkpoint
 from torch import nn
 
 from adapters.composition import adjust_tensors_for_parallel, match_attn_matrices_for_parallel
-from transformers.models.vit.modeling_vit import ViTLayer, ViTOutput, ViTSdpaSelfAttention, ViTSelfAttention
+from transformers.models.vit.modeling_vit import ViTLayer, ViTOutput, ViTSelfAttention
+from transformers.utils import logging
+from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
+from transformers.models.vit.modeling_vit import eager_attention_forward
 
 from .mixin_vit import ViTLayerAdaptersMixin, ViTOutputAdaptersMixin, ViTSelfAttentionAdaptersMixin
 
+logger = logging.get_logger(__name__)
 
 class ViTSelfAttentionWithAdapters(ViTSelfAttentionAdaptersMixin, ViTSelfAttention):
     def forward(
         self, hidden_states, head_mask: Optional[torch.Tensor] = None, output_attentions: bool = False
     ) -> Union[Tuple[torch.Tensor, torch.Tensor], Tuple[torch.Tensor]]:
-        mixed_query_layer = self.query(hidden_states)
-
         key_layer = self.transpose_for_scores(self.key(hidden_states))
         value_layer = self.transpose_for_scores(self.value(hidden_states))
-        query_layer = self.transpose_for_scores(mixed_query_layer)
+        query_layer = self.transpose_for_scores(self.query(hidden_states))
 
         query_layer, key_layer, value_layer = match_attn_matrices_for_parallel(query_layer, key_layer, value_layer)
 
         key_layer, value_layer, _ = self.prefix_tuning(key_layer, value_layer, hidden_states)
         (query_layer,) = adjust_tensors_for_parallel(key_layer, query_layer)
 
-        # Take the dot product between "query" and "key" to get the raw attention scores.
-        attention_scores = torch.matmul(query_layer, key_layer.transpose(-1, -2))
+        attention_interface: Callable = eager_attention_forward
+        if self.config._attn_implementation != "eager":
+            if self.config._attn_implementation == "sdpa" and output_attentions:
+                logger.warning_once(
+                    "`torch.nn.functional.scaled_dot_product_attention` does not support `output_attentions=True`. Falling back to "
+                    'eager attention. This warning can be removed using the argument `attn_implementation="eager"` when loading the model.'
+                )
+            else:
+                attention_interface = ALL_ATTENTION_FUNCTIONS[self.config._attn_implementation]
 
-        attention_scores = attention_scores / math.sqrt(self.attention_head_size)
-
-        # Normalize the attention scores to probabilities.
-        attention_probs = nn.functional.softmax(attention_scores, dim=-1)
-
-        # This is actually dropping out entire tokens to attend to, which might
-        # seem a bit unusual, but is taken from the original Transformer paper.
-        attention_probs = self.dropout(attention_probs)
-
-        # Mask heads if we want to
-        if head_mask is not None:
-            attention_probs = attention_probs * head_mask
-
-        context_layer = torch.matmul(attention_probs, value_layer)
-
-        context_layer = context_layer.permute(0, 2, 1, 3).contiguous()
-        new_context_layer_shape = context_layer.size()[:-2] + (self.all_head_size,)
-        context_layer = context_layer.view(new_context_layer_shape)
-
-        outputs = (context_layer, attention_probs) if output_attentions else (context_layer,)
-
-        return outputs
-
-
-class ViTSdpaSelfAttentionWithAdapters(ViTSelfAttentionAdaptersMixin, ViTSdpaSelfAttention):
-    def forward(
-        self, hidden_states, head_mask: Optional[torch.Tensor] = None, output_attentions: bool = False
-    ) -> Union[Tuple[torch.Tensor, torch.Tensor], Tuple[torch.Tensor]]:
-        mixed_query_layer = self.query(hidden_states)
-
-        key_layer = self.transpose_for_scores(self.key(hidden_states))
-        value_layer = self.transpose_for_scores(self.value(hidden_states))
-        query_layer = self.transpose_for_scores(mixed_query_layer)
-
-        query_layer, key_layer, value_layer = match_attn_matrices_for_parallel(query_layer, key_layer, value_layer)
-
-        key_layer, value_layer, _ = self.prefix_tuning(key_layer, value_layer, hidden_states)
-        (query_layer,) = adjust_tensors_for_parallel(key_layer, query_layer)
-
-        context_layer = torch.nn.functional.scaled_dot_product_attention(
+        context_layer, attention_probs = attention_interface(
+            self,
             query_layer,
             key_layer,
             value_layer,
             head_mask,
-            self.attention_probs_dropout_prob if self.training else 0.0,
-            is_causal=False,
-            scale=None,
+            is_causal=self.is_causal,
+            scaling=self.scaling,
+            dropout=0.0 if not self.training else self.dropout_prob,
         )
 
-        context_layer = context_layer.permute(0, 2, 1, 3).contiguous()
         new_context_layer_shape = context_layer.size()[:-2] + (self.all_head_size,)
-        context_layer = context_layer.view(new_context_layer_shape)
+        context_layer = context_layer.reshape(new_context_layer_shape)
 
-        return context_layer, None
+        outputs = (context_layer, attention_probs) if output_attentions else (context_layer,)
+
+        return outputs
 
 
 class ViTOutputWithAdapters(ViTOutputAdaptersMixin, ViTOutput):

--- a/src/adapters/models/vit/modeling_vit.py
+++ b/src/adapters/models/vit/modeling_vit.py
@@ -23,14 +23,15 @@ import torch.utils.checkpoint
 from torch import nn
 
 from adapters.composition import adjust_tensors_for_parallel, match_attn_matrices_for_parallel
-from transformers.models.vit.modeling_vit import ViTLayer, ViTOutput, ViTSelfAttention
-from transformers.utils import logging
 from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
-from transformers.models.vit.modeling_vit import eager_attention_forward
+from transformers.models.vit.modeling_vit import ViTLayer, ViTOutput, ViTSelfAttention, eager_attention_forward
+from transformers.utils import logging
 
 from .mixin_vit import ViTLayerAdaptersMixin, ViTOutputAdaptersMixin, ViTSelfAttentionAdaptersMixin
 
+
 logger = logging.get_logger(__name__)
+
 
 class ViTSelfAttentionWithAdapters(ViTSelfAttentionAdaptersMixin, ViTSelfAttention):
     def forward(

--- a/src/adapters/models/vit/modeling_vit.py
+++ b/src/adapters/models/vit/modeling_vit.py
@@ -15,11 +15,9 @@
 """PyTorch ViT model."""
 
 
-import math
 from typing import Callable, Optional, Tuple, Union
 
 import torch
-import torch.utils.checkpoint
 from torch import nn
 
 from adapters.composition import adjust_tensors_for_parallel, match_attn_matrices_for_parallel

--- a/src/adapters/models/vit/modeling_vit.py
+++ b/src/adapters/models/vit/modeling_vit.py
@@ -18,7 +18,6 @@
 from typing import Callable, Optional, Tuple, Union
 
 import torch
-from torch import nn
 
 from adapters.composition import adjust_tensors_for_parallel, match_attn_matrices_for_parallel
 from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS

--- a/tests/test_models/base.py
+++ b/tests/test_models/base.py
@@ -18,3 +18,6 @@ class AdapterModelTesterMixin:
 
     def test_correct_missing_keys(self):
         self.skipTest("Not applicable.")
+
+    def test_generation_tester_mixin_inheritance(self):
+        self.skipTest("Not applicable.")  # AdapterModel classes are not generative as is (ie without a LM head)

--- a/tests/test_models/base.py
+++ b/tests/test_models/base.py
@@ -3,6 +3,10 @@ from transformers.testing_utils import require_torch
 
 @require_torch
 class AdapterModelTesterMixin:
+    @property
+    def all_generative_model_classes(self):
+        return tuple()  # AdapterModel classes are not generative as is (ie without a LM head)
+
     def test_training(self):
         self.skipTest("Not applicable.")
 


### PR DESCRIPTION
Changes required for compatibility to v4.50:
- Refactor automatic static to flex head conversion on full model loading
- Update Beit and Vit attention implementations
- Skip generation tests for AdapterModel classes