### PR TITLE
HotFix: Remove accidental pdb.set_trace() call from test file

### DIFF
--- a/tests/test_misc/test_adapter_composition.py
+++ b/tests/test_misc/test_adapter_composition.py
@@ -39,7 +39,6 @@ class AdapterCompositionParsingTest(unittest.TestCase):
 @require_torch
 class AdapterCompositionTest(unittest.TestCase):
     unsupported_blocks = []
-    __import__("pdb").set_trace()
 
     def get_adapter_config(self):
         return SeqBnConfig()


### PR DESCRIPTION
This PR removes a hidden pdb.set_trace() call in test_adapter_composition.py:

``` python
__import__("pdb").set_trace()
```

### Problem
This line caused the test runner (pytest) to pause execution and wait for user input during test discovery or execution. Since it's not in an interactive terminal (especially when running via VS Code or CI), it appears as if the tests are hanging or failing silently.
It looks like this was a leftover debugging breakpoint that was accidentally committed.

### Fix
The line has been removed to allow the test suite to run normally without interactive interruption.
After removing this, test discovery and execution complete successfully.