### PR TITLE
Upgrade transformers to 4.51.3

### DIFF
--- a/examples/pytorch/dependency-parsing/utils_udp.py
+++ b/examples/pytorch/dependency-parsing/utils_udp.py
@@ -25,14 +25,9 @@ from transformers import (
     Trainer,
     TrainerCallback,
     TrainingArguments,
-    is_torch_tpu_available,
 )
 from transformers.trainer_utils import PredictionOutput
 
-
-if is_torch_tpu_available():
-    import torch_xla.core.xla_model as xm
-    import torch_xla.debug.metrics as met
 
 logger = logging.getLogger(__name__)
 
@@ -241,10 +236,6 @@ class DependencyParsingTrainer(Trainer):
             self.store_best_model(output)
 
         self.log(output.metrics)
-
-        if self.args.tpu_metrics_debug:
-            # tpu-comment: Logging debug metrics for PyTorch/XLA (compile, execute times, ops, etc.)
-            xm.master_print(met.metrics_report())
 
         return output.metrics
 

--- a/examples/pytorch/question-answering/trainer_qa.py
+++ b/examples/pytorch/question-answering/trainer_qa.py
@@ -19,13 +19,8 @@ import math
 import time
 
 from adapters.trainer import AdapterTrainer
-from transformers import Trainer, is_torch_tpu_available
+from transformers import Trainer
 from transformers.trainer_utils import PredictionOutput, speed_metrics
-
-
-if is_torch_tpu_available(check_device=False):
-    import torch_xla.core.xla_model as xm
-    import torch_xla.debug.metrics as met
 
 
 class QuestionAnsweringTrainer(Trainer):
@@ -83,10 +78,6 @@ class QuestionAnsweringTrainer(Trainer):
         if self.args.should_log:
             # Only the main node log the results by default
             self.log(metrics)
-
-        if self.args.tpu_metrics_debug or self.args.debug:
-            # tpu-comment: Logging debug metrics for PyTorch/XLA (compile, execute times, ops, etc.)
-            xm.master_print(met.metrics_report())
 
         self.control = self.callback_handler.on_evaluate(self.args, self.state, self.control, metrics)
         return metrics

--- a/examples/pytorch/question-answering/trainer_seq2seq_qa.py
+++ b/examples/pytorch/question-answering/trainer_seq2seq_qa.py
@@ -22,13 +22,8 @@ from typing import Dict, List, Optional
 from torch.utils.data import Dataset
 
 from adapters import AdapterTrainer
-from transformers import Seq2SeqTrainer, is_torch_tpu_available
+from transformers import Seq2SeqTrainer
 from transformers.trainer_utils import PredictionOutput, speed_metrics
-
-
-if is_torch_tpu_available(check_device=False):
-    import torch_xla.core.xla_model as xm
-    import torch_xla.debug.metrics as met
 
 
 class QuestionAnsweringSeq2SeqTrainer(Seq2SeqTrainer):
@@ -105,10 +100,6 @@ class QuestionAnsweringSeq2SeqTrainer(Seq2SeqTrainer):
         if self.args.should_log:
             # Only the main node log the results by default
             self.log(metrics)
-
-        if self.args.tpu_metrics_debug or self.args.debug:
-            # tpu-comment: Logging debug metrics for PyTorch/XLA (compile, execute times, ops, etc.)
-            xm.master_print(met.metrics_report())
 
         self.control = self.callback_handler.on_evaluate(self.args, self.state, self.control, metrics)
         return metrics

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ _deps = [
     "timeout-decorator",
     "torch",
     "torchvision",
-    "transformers~=4.50.3",
+    "transformers~=4.51.3",
 ]
 
 

--- a/src/adapters/methods/lora.py
+++ b/src/adapters/methods/lora.py
@@ -1070,11 +1070,13 @@ class LoRAMergedLinear(LoRALayer, nn.Linear):
             # Actual trainable parameters
             if any(lora.enable_lora):
                 # Compute the indices
-                lora.lora_ind = self.weight.new_zeros((self.out_features,), dtype=torch.bool).view(
+                # Ensure we're not creating a meta tensor
+                device = self.weight.device if self.weight.device.type != "meta" else torch.device("cpu")
+                lora_ind = torch.zeros((self.out_features,), dtype=torch.bool, device=device).view(
                     len(lora.enable_lora), -1
                 )
-                lora.lora_ind[lora.enable_lora, :] = True
-                lora.lora_ind = lora.lora_ind.view(-1)
+                lora_ind[lora.enable_lora, :] = True
+                lora.lora_ind = lora_ind.view(-1)
             return True
         else:
             return False

--- a/src/adapters/methods/modeling.py
+++ b/src/adapters/methods/modeling.py
@@ -392,8 +392,17 @@ class BertFusion(nn.Module):
             self.value = nn.Linear(self.dense_size, self.dense_size, bias=False)
             self.value.apply(Adapter.init_bert_weights)
             if self.config["value_initialized"]:
-                self.value.weight.data = (torch.zeros(self.dense_size, self.dense_size) + 0.000001).fill_diagonal_(1.0)
-
+                init_tensor = (
+                    torch.zeros(
+                        self.dense_size,
+                        self.dense_size,
+                        device=self.value.weight.device,
+                        dtype=self.value.weight.dtype,
+                    )
+                    + 0.000001
+                )
+                init_tensor.fill_diagonal_(1.0)
+                self.value.weight.data = init_tensor
         if self.config["temperature"]:
             self.T = 50.0
         else:

--- a/src/adapters/methods/reft.py
+++ b/src/adapters/methods/reft.py
@@ -42,6 +42,8 @@ class ReftUnit(nn.Module):
                     UserWarning,
                 )
                 projection = projection.to(dtype=torch.float32)
+            if projection.weight.device == torch.device("meta"):
+                projection = projection.to_empty(device="cpu")
             self.projection = nn.utils.parametrizations.orthogonal(projection)
         else:
             self.projection = projection

--- a/tests/test_models/test_clip_model.py
+++ b/tests/test_models/test_clip_model.py
@@ -3,7 +3,10 @@ import numpy as np
 
 from adapters import CLIPAdapterModel
 from hf_transformers.tests.models.clip.test_modeling_clip import *  # Imported to execute model tests
-from hf_transformers.tests.test_modeling_common import _config_zero_init
+from hf_transformers.tests.test_modeling_common import (
+    TEST_EAGER_MATCHES_SDPA_INFERENCE_PARAMETERIZATION,
+    _config_zero_init,
+)
 from transformers.testing_utils import require_torch
 
 from .base import AdapterModelTesterMixin
@@ -42,3 +45,11 @@ class CLIPAdapterModelTest(AdapterModelTesterMixin, CLIPModelTest):
         # CLIPAdapterModel does not support gradient checkpointing (because enable_input_require_grads is not implemented by Hugging Face,
         # which is required for gradient checkpointing with parameter efficient fine-tuning methods).
         self.skipTest("CLIPAdapterModel does not support gradient checkpointing")
+
+    @parameterized.expand(TEST_EAGER_MATCHES_SDPA_INFERENCE_PARAMETERIZATION)
+    @require_torch_sdpa
+    def test_eager_matches_sdpa_inference(
+        self, name, torch_dtype, padding_side, use_attention_mask, output_attentions, enable_kernels
+    ):
+        # Explicitly skip for CLIPAdapterModel as it's a CLIP-like model
+        self.skipTest(reason="CLIP-like models have a different implementation for SDPA tests")


### PR DESCRIPTION
This PR upgrades transformers to v4.51.x.

Required changes in the adapters code base:
- Properly skip sdpa inference tests for CLIP
- Remove deprecated tpu availability method from example scripts
- Update weight initialization for BertFusion
- Avoid tensor allocation on meta device for LoRA and REFT parametrization