### PR TITLE
Add EAT model interface for LoRA adapter support

### DIFF
--- a/docs/model_overview.md
+++ b/docs/model_overview.md
@@ -23,6 +23,7 @@ The table below further shows which model architectures support which adaptation
 | [DeBERTa](classes/models/deberta.html) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | [DeBERTa-v2](classes/models/debertaV2.html) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | [DistilBERT](classes/models/distilbert.html) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| [EAT](https://huggingface.co/worstchan/EAT-base_epoch30_pretrain)<sup>◊</sup> | | | ✅ | | | | | | |
 | [Electra](classes/models/electra.html) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | [Encoder Decoder](classes/models/encoderdecoder.html) | (*) | (*) | (*) | (*) | (*) | (*) | | | (*) |
 | Gemma 2<sup>◊</sup>                    | ✅ |  | ✅ | ✅ | ✅ | ✅ |  |  | ✅ |

--- a/src/adapters/wrappers/interfaces.py
+++ b/src/adapters/wrappers/interfaces.py
@@ -112,6 +112,21 @@ CUSTOM_INTERFACES = {
         layer_ln_1=None,
         layer_ln_2=None,
     ),
+    "eat": AdapterModelInterface(
+        adapter_methods=["lora"],
+        model_embeddings="model.local_encoder",
+        model_layers="model.blocks",
+        layer_self_attn="attn",
+        layer_cross_attn=None,
+        attn_qkv_proj="qkv",
+        attn_o_proj="proj",
+        layer_intermediate_proj="mlp.fc1",
+        layer_output_proj="mlp.fc2",
+        layer_pre_self_attn="norm1",
+        layer_pre_ffn="norm2",
+        layer_ln_1=None,
+        layer_ln_2=None,
+    ),
 }
 
 

--- a/tests/test_methods/test_all_custom_interfaces.py
+++ b/tests/test_methods/test_all_custom_interfaces.py
@@ -2,6 +2,9 @@ import os
 import tempfile
 import unittest
 
+import torch
+import torch.nn as nn
+
 import adapters
 from adapters import CompacterPlusPlusConfig, IA3Config, LoRAConfig
 from tests.test_methods.method_test_impl.base import AdapterMethodBaseTestMixin
@@ -11,12 +14,117 @@ from transformers import (
     Gemma3TextConfig,
     ModernBertConfig,
     PhiConfig,
+    PretrainedConfig,
+    PreTrainedModel,
     Qwen2Config,
     Qwen3Config,
 )
+from transformers.modeling_outputs import BaseModelOutput
 from transformers.testing_utils import torch_device
 
-from .base import TextAdapterTestBase
+from .base import TextAdapterTestBase, VisionAdapterTestBase
+
+
+# ---------------------------------------------------------------------------
+# Vendored minimal EAT model for testing
+# ---------------------------------------------------------------------------
+# EATConfig is NOT in transformers (requires trust_remote_code=True on HF Hub),
+# so we vendor a tiny model with the correct module hierarchy to test the
+# custom interface without any external dependencies.
+
+
+class _EATConfig(PretrainedConfig):
+    model_type = "eat"
+
+    def __init__(self, embed_dim=32, depth=4, num_heads=4, mlp_ratio=2, img_size=(64, 128), patch_size=16, **kwargs):
+        super().__init__(**kwargs)
+        self.embed_dim = embed_dim
+        self.depth = depth
+        self.num_heads = num_heads
+        self.mlp_ratio = mlp_ratio
+        self.img_size = img_size
+        self.patch_size = patch_size
+
+
+class _EATAttention(nn.Module):
+    def __init__(self, dim, num_heads):
+        super().__init__()
+        self.num_heads = num_heads
+        self.qkv = nn.Linear(dim, dim * 3)
+        self.proj = nn.Linear(dim, dim)
+
+    def forward(self, x):
+        B, N, C = x.shape
+        qkv = self.qkv(x).reshape(B, N, 3, self.num_heads, C // self.num_heads).permute(2, 0, 3, 1, 4)
+        q, k, v = qkv.unbind(0)
+        attn = (q @ k.transpose(-2, -1)) * ((C // self.num_heads) ** -0.5)
+        attn = attn.softmax(dim=-1)
+        x = (attn @ v).transpose(1, 2).reshape(B, N, C)
+        return self.proj(x)
+
+
+class _EATMlp(nn.Module):
+    def __init__(self, dim, mlp_ratio):
+        super().__init__()
+        self.fc1 = nn.Linear(dim, int(dim * mlp_ratio))
+        self.act = nn.GELU()
+        self.fc2 = nn.Linear(int(dim * mlp_ratio), dim)
+
+    def forward(self, x):
+        return self.fc2(self.act(self.fc1(x)))
+
+
+class _EATBlock(nn.Module):
+    def __init__(self, dim, num_heads, mlp_ratio):
+        super().__init__()
+        self.norm1 = nn.LayerNorm(dim)
+        self.attn = _EATAttention(dim, num_heads)
+        self.norm2 = nn.LayerNorm(dim)
+        self.mlp = _EATMlp(dim, mlp_ratio)
+
+    def forward(self, x):
+        x = x + self.attn(self.norm1(x))
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+
+class _EATBackbone(nn.Module):
+    """Mimics the inner EAT backbone (model.local_encoder, model.blocks)."""
+
+    def __init__(self, config):
+        super().__init__()
+        self.local_encoder = nn.Conv2d(1, config.embed_dim, kernel_size=config.patch_size, stride=config.patch_size)
+        self.cls_token = nn.Parameter(torch.zeros(1, 1, config.embed_dim))
+        self.blocks = nn.ModuleList(
+            [_EATBlock(config.embed_dim, config.num_heads, config.mlp_ratio) for _ in range(config.depth)]
+        )
+        self.norm = nn.LayerNorm(config.embed_dim)
+
+    def forward(self, pixel_values):
+        # pixel_values: (B, 1, T, F)
+        x = self.local_encoder(pixel_values)  # (B, embed_dim, H, W)
+        x = x.flatten(2).transpose(1, 2)  # (B, num_patches, embed_dim)
+        cls = self.cls_token.expand(x.shape[0], -1, -1)
+        x = torch.cat([cls, x], dim=1)
+        for blk in self.blocks:
+            x = blk(x)
+        return self.norm(x)
+
+
+class _EATModel(PreTrainedModel):
+    config_class = _EATConfig
+    base_model_prefix = ""
+
+    def __init__(self, config):
+        super().__init__(config)
+        self.model = _EATBackbone(config)
+
+    def get_input_embeddings(self):
+        raise NotImplementedError("Audio models have no token embeddings.")
+
+    def forward(self, pixel_values, **kwargs):
+        x = self.model(pixel_values)
+        return BaseModelOutput(last_hidden_state=x)
 
 
 # To add tests for a new model, add a new entry to this dictionary. Nothing else needs to be changed.
@@ -222,3 +330,20 @@ for model_name, model_config in MODEL_CONFIGS.items():
 
     # Add test class to global namespace
     globals()[model_name] = test_class
+
+
+class EATCustomInterfaceTest(CustomInterfaceTestBase, VisionAdapterTestBase, unittest.TestCase):
+    """Tests for the EAT custom interface (LoRA-only audio model)."""
+
+    config_class = _EATConfig
+    input_shape = (3, 1, 64, 128)  # (batch, channels, time, freq)
+
+    @staticmethod
+    def config():
+        return _EATConfig(embed_dim=32, depth=4, num_heads=4, img_size=(64, 128))
+
+    def get_model(self):
+        model = _EATModel(self.config())
+        adapters.init(model)
+        model.to(torch_device)
+        return model


### PR DESCRIPTION
## Summary

Adds [EAT (Efficient Audio Transformer)](https://arxiv.org/abs/2401.03497) to `CUSTOM_INTERFACES` so that `adapters.init(model)` auto-detects it, removing the need for users to manually define and pass an interface.

HuggingFace model cards:
- Pretrained: [worstchan/EAT-base_epoch30_pretrain](https://huggingface.co/worstchan/EAT-base_epoch30_pretrain)
- Fine-tuned (AudioSet-2M): [worstchan/EAT-base_epoch30_finetune_AS2M](https://huggingface.co/worstchan/EAT-base_epoch30_finetune_AS2M)

### Changes

- **`src/adapters/wrappers/interfaces.py`**: Add `"eat"` entry to `CUSTOM_INTERFACES` with `adapter_methods=["lora"]`, mapping to fused QKV attention (`attn.qkv`/`attn.proj`), FFN (`mlp.fc1`/`mlp.fc2`), and pre-norm layers (`norm1`/`norm2`).
- **`tests/test_methods/test_all_custom_interfaces.py`**: Vendor a minimal EAT model (tiny dimensions, no external dependencies) and add `EATCustomInterfaceTest`. 4 tests pass, 5 skipped.
- **`docs/model_overview.md`**: Add EAT to the model support table (LoRA only).

### Why `adapter_methods=["lora"]` only

EATConfig uses `embed_dim` / `num_heads` instead of `hidden_size` / `num_attention_heads`. Bottleneck, ReFT, prefix tuning, and invertible adapters all read these standard config attributes and would crash. LoRA works purely with module references via `init_lora()` and never reads config attributes, so it works out of the box.

### Prerequisites

This PR builds on two previously merged fixes:
- #830: Fix `LoRAMergedLinear.get_n_heads()` for fused QKV models
- #831: Handle `NotImplementedError` from `get_input_embeddings()` for audio/vision models

## Test plan

- [x] `pytest tests/test_methods/test_all_custom_interfaces.py -k "EAT" -v` -- 4 passed, 5 skipped
- [x] `pytest tests/test_methods/test_all_custom_interfaces.py -v` -- 52 passed, 11 skipped, no regressions